### PR TITLE
fix: custom views disparaissent dans les paramètres

### DIFF
--- a/src/components/atomic-crm/root/ConfigurationContext.tsx
+++ b/src/components/atomic-crm/root/ConfigurationContext.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useStore } from "ra-core";
 
 import type { DealStage, LabeledValue, NoteStatus } from "../types";
@@ -46,4 +46,30 @@ export const useConfigurationUpdater = () => {
     CONFIGURATION_STORE_KEY,
   );
   return setConfig;
+};
+
+/**
+ * Hook to read/write only the `customViews` field in the store.
+ * Uses the raw stored config (not merged with defaults) to avoid
+ * creating new references for unrelated fields (companySectors, dealStages…)
+ * which would cause SettingsForm's defaultValues to change and reset the form.
+ */
+export const useCustomViewsStore = (): [
+  CustomView[],
+  (views: CustomView[]) => void,
+] => {
+  const [storedConfig, setStoredConfig] = useStore<
+    Partial<ConfigurationContextValue>
+  >(CONFIGURATION_STORE_KEY, {});
+  const setCustomViews = useCallback(
+    (views: CustomView[]) => {
+      setStoredConfig({ ...storedConfig, customViews: views });
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [storedConfig],
+  );
+  return [
+    storedConfig.customViews ?? defaultConfiguration.customViews,
+    setCustomViews,
+  ];
 };

--- a/src/components/atomic-crm/settings/SettingsPage.tsx
+++ b/src/components/atomic-crm/settings/SettingsPage.tsx
@@ -15,6 +15,7 @@ import ImageEditorField from "../misc/ImageEditorField";
 import {
   useConfigurationContext,
   useConfigurationUpdater,
+  useCustomViewsStore,
   type ConfigurationContextValue,
   type CustomView,
 } from "../root/ConfigurationContext";
@@ -416,9 +417,8 @@ const SettingsFormFields = () => {
 };
 
 const CustomViewsSection = () => {
-  const config = useConfigurationContext();
-  const { customViews, dealStages, companyTypes } = config;
-  const updateConfiguration = useConfigurationUpdater();
+  const { dealStages, companyTypes } = useConfigurationContext();
+  const [customViews, setCustomViews] = useCustomViewsStore();
 
   const { data: allSales } = useGetList("sales", {
     pagination: { page: 1, perPage: 100 },
@@ -427,10 +427,7 @@ const CustomViewsSection = () => {
   });
 
   const handleDeleteView = (viewId: string) => {
-    updateConfiguration({
-      ...config,
-      customViews: customViews.filter((v) => v.id !== viewId),
-    });
+    setCustomViews(customViews.filter((v) => v.id !== viewId));
   };
 
   const handleToggleStage = (view: CustomView, stageValue: string) => {
@@ -443,21 +440,19 @@ const CustomViewsSection = () => {
     } else {
       newVisible = [...currentVisible, stageValue];
     }
-    updateConfiguration({
-      ...config,
-      customViews: customViews.map((v) =>
+    setCustomViews(
+      customViews.map((v) =>
         v.id === view.id ? { ...v, visibleStages: newVisible } : v,
       ),
-    });
+    );
   };
 
   const handleResetStages = (viewId: string) => {
-    updateConfiguration({
-      ...config,
-      customViews: customViews.map((v) =>
+    setCustomViews(
+      customViews.map((v) =>
         v.id === viewId ? { ...v, visibleStages: undefined } : v,
       ),
-    });
+    );
   };
 
   const handleToggleUser = (view: CustomView, userId: number) => {
@@ -466,21 +461,19 @@ const CustomViewsSection = () => {
     const newAllowed = isAllowed
       ? current.filter((id) => id !== userId)
       : [...current, userId];
-    updateConfiguration({
-      ...config,
-      customViews: customViews.map((v) =>
+    setCustomViews(
+      customViews.map((v) =>
         v.id === view.id ? { ...v, allowedUserIds: newAllowed } : v,
       ),
-    });
+    );
   };
 
   const handleSetAllUsers = (viewId: string) => {
-    updateConfiguration({
-      ...config,
-      customViews: customViews.map((v) =>
+    setCustomViews(
+      customViews.map((v) =>
         v.id === viewId ? { ...v, allowedUserIds: undefined } : v,
       ),
-    });
+    );
   };
 
   return (


### PR DESCRIPTION
Corrige le bug où les vues personnalisées disparaissent quand on toggle les étapes dans Paramètres > Vues.

**Root cause**:  étalait la config fusionnée (defaults + stored) dans le store. Ça créait de nouvelles références pour , , etc. →  dans  changeait → la  se réinitialisait → corruption du state des vues.

**Fix**: Nouveau hook  qui lit/écrit uniquement le champ  dans le store raw (sans merger avec les defaults). Ainsi les autres champs gardent leurs références stables.