### PR TITLE
fix: créer une opportunité depuis une vue reste dans la bonne vue

### DIFF
--- a/src/components/atomic-crm/deals/DealEmpty.tsx
+++ b/src/components/atomic-crm/deals/DealEmpty.tsx
@@ -1,7 +1,8 @@
 import { useGetList } from "ra-core";
-import { matchPath, useLocation, Link } from "react-router";
+import { matchPath, useLocation, Link, useNavigate } from "react-router";
 import type { ReactNode } from "react";
-import { CreateButton } from "@/components/admin/create-button";
+import { Plus } from "lucide-react";
+import { buttonVariants } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 
 import useAppBarHeight from "../misc/useAppBarHeight";
@@ -11,6 +12,9 @@ import { DealCreate } from "./DealCreate";
 export const DealEmpty = ({ children }: { children?: ReactNode }) => {
   const location = useLocation();
   const matchCreate = matchPath("/deals/create", location.pathname);
+  const matchViewCreate = matchPath("/views/:viewId/create", location.pathname);
+  const viewId = matchViewCreate?.params.viewId;
+  const navigate = useNavigate();
   const appbarHeight = useAppBarHeight();
 
   // get Contact data
@@ -40,9 +44,17 @@ export const DealEmpty = ({ children }: { children?: ReactNode }) => {
             </p>
           </div>
           <div className="flex space-x-8">
-            <CreateButton label="Créer une opportunité" />
+            <button
+              className={buttonVariants({ variant: "outline" })}
+              onClick={() =>
+                navigate(viewId ? `/views/${viewId}/create` : "/deals/create")
+              }
+            >
+              <Plus />
+              Créer une opportunité
+            </button>
           </div>
-          <DealCreate open={!!matchCreate} />
+          <DealCreate open={!!matchCreate || !!matchViewCreate} />
           {children}
         </>
       ) : (

--- a/src/components/atomic-crm/deals/DealListForView.tsx
+++ b/src/components/atomic-crm/deals/DealListForView.tsx
@@ -1,7 +1,8 @@
 import { useCanAccess, useGetIdentity, useListContext } from "ra-core";
-import { matchPath, Navigate, useLocation, useParams } from "react-router";
+import { matchPath, Navigate, useLocation, useNavigate, useParams } from "react-router";
+import { Plus } from "lucide-react";
+import { buttonVariants } from "@/components/ui/button";
 import { AutocompleteInput } from "@/components/admin/autocomplete-input";
-import { CreateButton } from "@/components/admin/create-button";
 import { ExportButton } from "@/components/admin/export-button";
 import { List } from "@/components/admin/list";
 import { ReferenceInput } from "@/components/admin/reference-input";
@@ -113,10 +114,20 @@ const DealViewLayout = () => {
   );
 };
 
-const DealViewActions = () => (
-  <TopToolbar>
-    <FilterButton />
-    <ExportButton />
-    <CreateButton label="Nouvelle opportunité" />
-  </TopToolbar>
-);
+const DealViewActions = () => {
+  const { viewId } = useParams<{ viewId: string }>();
+  const navigate = useNavigate();
+  return (
+    <TopToolbar>
+      <FilterButton />
+      <ExportButton />
+      <button
+        className={buttonVariants({ variant: "outline" })}
+        onClick={() => navigate(`/views/${viewId}/create`)}
+      >
+        <Plus />
+        Nouvelle opportunité
+      </button>
+    </TopToolbar>
+  );
+};


### PR DESCRIPTION
Corrige le bug où créer une opportunité depuis une vue personnalisée redirigeait vers la vue Opportunités.

**Root cause**: CreateButton utilisait useCreatePath (ra-core) qui génère toujours /deals/create basé sur le resource context, ignorant /views/:viewId. Le dialog DealCreate ne souvrait jamais dans la vue, et la redirection post-création allait sur /deals.

**Fix**:
- DealViewActions: remplace CreateButton par un bouton navigate vers /views/:viewId/create
- DealEmpty: détecte /views/:viewId/create pour ouvrir le dialog et pointer le bouton vers la bonne URL