### PR TITLE
fix: persist kanban views (React Query cache sync)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,10 @@
 
 Atomic CRM is a full-featured CRM built with React, shadcn-admin-kit, and Supabase. It provides contact management, task tracking, notes, email capture, and deal management with a Kanban board.
 
+## Deployment
+
+The CRM is deployed via **Coolify**. Every push to GitHub triggers an automatic **preview deployment**. There is no Vercel deployment for this project.
+
 ## Development Commands
 
 ### Setup

--- a/src/components/atomic-crm/deals/CreateViewDialog.tsx
+++ b/src/components/atomic-crm/deals/CreateViewDialog.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router";
+import { useDataProvider } from "ra-core";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -23,6 +24,7 @@ import {
   useConfigurationUpdater,
   type CustomView,
 } from "../root/ConfigurationContext";
+import type { CrmDataProvider } from "../providers/types";
 
 interface CreateViewDialogProps {
   open: boolean;
@@ -31,15 +33,17 @@ interface CreateViewDialogProps {
 
 export const CreateViewDialog = ({ open, onClose }: CreateViewDialogProps) => {
   const updateConfiguration = useConfigurationUpdater();
+  const dataProvider = useDataProvider<CrmDataProvider>();
   const navigate = useNavigate();
 
   const [label, setLabel] = useState("");
   const [companyType, setCompanyType] = useState("");
+  const [saving, setSaving] = useState(false);
 
   const config = useConfigurationContext();
   const { companyTypes } = config;
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (!label.trim() || !companyType) return;
 
     const id = `view-${Date.now()}`;
@@ -49,10 +53,18 @@ export const CreateViewDialog = ({ open, onClose }: CreateViewDialogProps) => {
       companyType,
     };
 
-    updateConfiguration({
+    const newConfig = {
       ...config,
       customViews: [...(config.customViews ?? []), newView],
-    });
+    };
+
+    setSaving(true);
+    try {
+      await dataProvider.updateConfiguration(newConfig);
+      updateConfiguration(newConfig);
+    } finally {
+      setSaving(false);
+    }
 
     setLabel("");
     setCompanyType("");
@@ -106,7 +118,7 @@ export const CreateViewDialog = ({ open, onClose }: CreateViewDialogProps) => {
           </Button>
           <Button
             onClick={handleSubmit}
-            disabled={!label.trim() || !companyType}
+            disabled={!label.trim() || !companyType || saving}
           >
             Créer la vue
           </Button>

--- a/src/components/atomic-crm/deals/CreateViewDialog.tsx
+++ b/src/components/atomic-crm/deals/CreateViewDialog.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useNavigate } from "react-router";
 import { useDataProvider } from "ra-core";
+import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -34,6 +35,7 @@ interface CreateViewDialogProps {
 export const CreateViewDialog = ({ open, onClose }: CreateViewDialogProps) => {
   const updateConfiguration = useConfigurationUpdater();
   const dataProvider = useDataProvider<CrmDataProvider>();
+  const queryClient = useQueryClient();
   const navigate = useNavigate();
 
   const [label, setLabel] = useState("");
@@ -61,6 +63,7 @@ export const CreateViewDialog = ({ open, onClose }: CreateViewDialogProps) => {
     setSaving(true);
     try {
       await dataProvider.updateConfiguration(newConfig);
+      queryClient.setQueryData(["configuration"], newConfig);
       updateConfiguration(newConfig);
     } finally {
       setSaving(false);


### PR DESCRIPTION
Fixes custom views disappearing after creation.

- Save to Supabase before updating local store
- Sync React Query cache (`queryClient.setQueryData`) to prevent stale cache from overwriting the store via `useConfigurationLoader`