### PR TITLE
fix: preserve customViews when saving settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,10 @@
 
 Atomic CRM is a full-featured CRM built with React, shadcn-admin-kit, and Supabase. It provides contact management, task tracking, notes, email capture, and deal management with a Kanban board.
 
+## Deployment
+
+The CRM is deployed via **Coolify**. Every push to GitHub triggers an automatic **preview deployment**. There is no Vercel deployment for this project.
+
 ## Development Commands
 
 ### Setup

--- a/src/components/atomic-crm/deals/CreateViewDialog.tsx
+++ b/src/components/atomic-crm/deals/CreateViewDialog.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router";
+import { useDataProvider } from "ra-core";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -23,6 +24,7 @@ import {
   useConfigurationUpdater,
   type CustomView,
 } from "../root/ConfigurationContext";
+import type { CrmDataProvider } from "../providers/types";
 
 interface CreateViewDialogProps {
   open: boolean;
@@ -31,15 +33,17 @@ interface CreateViewDialogProps {
 
 export const CreateViewDialog = ({ open, onClose }: CreateViewDialogProps) => {
   const updateConfiguration = useConfigurationUpdater();
+  const dataProvider = useDataProvider<CrmDataProvider>();
   const navigate = useNavigate();
 
   const [label, setLabel] = useState("");
   const [companyType, setCompanyType] = useState("");
+  const [saving, setSaving] = useState(false);
 
   const config = useConfigurationContext();
   const { companyTypes } = config;
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (!label.trim() || !companyType) return;
 
     const id = `view-${Date.now()}`;
@@ -49,10 +53,18 @@ export const CreateViewDialog = ({ open, onClose }: CreateViewDialogProps) => {
       companyType,
     };
 
-    updateConfiguration({
+    const newConfig = {
       ...config,
       customViews: [...(config.customViews ?? []), newView],
-    });
+    };
+
+    setSaving(true);
+    try {
+      await dataProvider.updateConfiguration(newConfig);
+      updateConfiguration(newConfig);
+    } finally {
+      setSaving(false);
+    }
 
     setLabel("");
     setCompanyType("");
@@ -106,7 +118,7 @@ export const CreateViewDialog = ({ open, onClose }: CreateViewDialogProps) => {
           </Button>
           <Button
             onClick={handleSubmit}
-            disabled={!label.trim() || !companyType}
+            disabled={!label.trim() || !companyType || saving}
           >
             Créer la vue
           </Button>

--- a/src/components/atomic-crm/deals/CreateViewDialog.tsx
+++ b/src/components/atomic-crm/deals/CreateViewDialog.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useNavigate } from "react-router";
 import { useDataProvider } from "ra-core";
+import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -34,6 +35,7 @@ interface CreateViewDialogProps {
 export const CreateViewDialog = ({ open, onClose }: CreateViewDialogProps) => {
   const updateConfiguration = useConfigurationUpdater();
   const dataProvider = useDataProvider<CrmDataProvider>();
+  const queryClient = useQueryClient();
   const navigate = useNavigate();
 
   const [label, setLabel] = useState("");
@@ -61,6 +63,7 @@ export const CreateViewDialog = ({ open, onClose }: CreateViewDialogProps) => {
     setSaving(true);
     try {
       await dataProvider.updateConfiguration(newConfig);
+      queryClient.setQueryData(["configuration"], newConfig);
       updateConfiguration(newConfig);
     } finally {
       setSaving(false);

--- a/src/components/atomic-crm/settings/SettingsPage.tsx
+++ b/src/components/atomic-crm/settings/SettingsPage.tsx
@@ -75,23 +75,30 @@ export const validateItemsInUse = (
   return undefined;
 };
 
-const transformFormValues = (data: Record<string, any>) => ({
-  config: {
-    title: data.title,
-    lightModeLogo: data.lightModeLogo,
-    darkModeLogo: data.darkModeLogo,
-    companySectors: ensureValues(data.companySectors),
-    dealCategories: ensureValues(data.dealCategories),
-    taskTypes: ensureValues(data.taskTypes),
-    dealStages: ensureValues(data.dealStages),
-    dealPipelineStatuses: data.dealPipelineStatuses,
-    noteStatuses: ensureValues(data.noteStatuses),
-  } as ConfigurationContextValue,
-});
-
 export const SettingsPage = () => {
   const updateConfiguration = useConfigurationUpdater();
   const notify = useNotify();
+  const [customViews] = useCustomViewsStore();
+  const { companyTypes } = useConfigurationContext();
+
+  const transform = useCallback(
+    (data: Record<string, any>) => ({
+      config: {
+        title: data.title,
+        lightModeLogo: data.lightModeLogo,
+        darkModeLogo: data.darkModeLogo,
+        companySectors: ensureValues(data.companySectors),
+        dealCategories: ensureValues(data.dealCategories),
+        taskTypes: ensureValues(data.taskTypes),
+        dealStages: ensureValues(data.dealStages),
+        dealPipelineStatuses: data.dealPipelineStatuses,
+        noteStatuses: ensureValues(data.noteStatuses),
+        customViews,
+        companyTypes,
+      } as ConfigurationContextValue,
+    }),
+    [customViews, companyTypes],
+  );
 
   return (
     <EditBase
@@ -99,7 +106,7 @@ export const SettingsPage = () => {
       id={1}
       mutationMode="pessimistic"
       redirect={false}
-      transform={transformFormValues}
+      transform={transform}
       mutationOptions={{
         onSuccess: (data: any) => {
           updateConfiguration(data.config);


### PR DESCRIPTION
## Summary

- `transformFormValues` était une fonction module-level sans accès au contexte, elle omettait `customViews` et `companyTypes`
- Chaque sauvegarde des paramètres écrasait la colonne `config` dans Supabase sans ces champs
- Les vues personnalisées disparaissaient définitivement après toute sauvegarde des settings

## Changements

- Déplace `transformFormValues` en `useCallback` dans `SettingsPage`
- Lit les `customViews` (via `useCustomViewsStore`) et `companyTypes` (via `useConfigurationContext`) actuels
- Les inclut dans chaque sauvegarde vers Supabase

## Test plan

- [ ] Créer une vue personnalisée dans le Kanban
- [ ] Aller dans Paramètres et sauvegarder (modifier n'importe quel champ)
- [ ] Vérifier que la vue apparaît toujours dans la navigation
- [ ] Recharger la page et vérifier que la vue persiste

https://claude.ai/code/session_0197eeuZRj23JCjgEin6QBxV