### PR TITLE
fix: trigger Google contacts sync from the UI

### DIFF
--- a/src/components/atomic-crm/providers/supabase/dataProvider.ts
+++ b/src/components/atomic-crm/providers/supabase/dataProvider.ts
@@ -351,6 +351,21 @@ const getDataProviderWithCustomMethods = () => {
       if (error) throw new Error("Failed to update Google preferences");
       return preferences;
     },
+    async syncGoogleContacts() {
+      const { data, error } = await getSupabaseClient().functions.invoke<{
+        data: {
+          total: number;
+          created: number;
+          updated: number;
+          skipped: number;
+        };
+      }>("google-contacts-sync", {
+        method: "POST",
+        body: { action: "sync" },
+      });
+      if (error) throw new Error("Failed to sync Google contacts");
+      return data!.data;
+    },
     async getUpcomingCalendarEvents(params: {
       timeMin: string;
       timeMax: string;
@@ -399,7 +414,9 @@ const getDataProviderWithCustomMethods = () => {
   } satisfies DataProvider;
 };
 
-export type CrmDataProvider = ReturnType<typeof getDataProviderWithCustomMethods>;
+export type CrmDataProvider = ReturnType<
+  typeof getDataProviderWithCustomMethods
+>;
 
 const processConfigLogo = async (logo: any): Promise<string> => {
   if (typeof logo === "string") return logo;
@@ -497,11 +514,9 @@ const lifeCycleCallbacks: ResourceCallbacks[] = [
   {
     resource: "contacts_summary",
     beforeGetList: async (params) => {
-      return applyFullTextSearch([
-        "first_name",
-        "last_name",
-        "company_name",
-      ])(params);
+      return applyFullTextSearch(["first_name", "last_name", "company_name"])(
+        params,
+      );
     },
   },
   {
@@ -603,8 +618,7 @@ const uploadToBucket = async (fi: RAFile) => {
     // Sign URL check if path exists in the bucket
     if (fi.path) {
       const { error } = await getSupabaseClient()
-        .storage
-        .from(ATTACHMENTS_BUCKET)
+        .storage.from(ATTACHMENTS_BUCKET)
         .createSignedUrl(fi.path, 60);
 
       if (!error) {
@@ -638,8 +652,7 @@ const uploadToBucket = async (fi: RAFile) => {
   const fileName = `${Math.random()}${fileExt}`;
   const filePath = `${fileName}`;
   const { error: uploadError } = await getSupabaseClient()
-    .storage
-    .from(ATTACHMENTS_BUCKET)
+    .storage.from(ATTACHMENTS_BUCKET)
     .upload(filePath, dataContent);
 
   if (uploadError) {
@@ -648,8 +661,7 @@ const uploadToBucket = async (fi: RAFile) => {
   }
 
   const { data } = getSupabaseClient()
-    .storage
-    .from(ATTACHMENTS_BUCKET)
+    .storage.from(ATTACHMENTS_BUCKET)
     .getPublicUrl(filePath);
 
   fi.path = filePath;

--- a/src/components/atomic-crm/settings/ConnectorsPage.tsx
+++ b/src/components/atomic-crm/settings/ConnectorsPage.tsx
@@ -15,6 +15,7 @@ import {
   EyeOff,
   Save,
   Trash2,
+  RefreshCw,
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -92,6 +93,7 @@ const GoogleConnectorCard = () => {
   const invalidate = useInvalidateGoogleStatus();
   const [connecting, setConnecting] = useState(false);
   const [disconnecting, setDisconnecting] = useState(false);
+  const [syncing, setSyncing] = useState(false);
 
   const handleConnect = useCallback(async () => {
     setConnecting(true);
@@ -127,6 +129,24 @@ const GoogleConnectorCard = () => {
       notify("Erreur lors de la révocation", { type: "error" });
     } finally {
       setDisconnecting(false);
+    }
+  }, [dataProvider, notify, invalidate]);
+
+  const handleSyncContacts = useCallback(async () => {
+    setSyncing(true);
+    try {
+      const result = await dataProvider.syncGoogleContacts();
+      notify(
+        `Synchronisation terminée : ${result.created} contact(s) importé(s)`,
+        { type: "success" },
+      );
+      invalidate();
+    } catch {
+      notify("Erreur lors de la synchronisation des contacts", {
+        type: "error",
+      });
+    } finally {
+      setSyncing(false);
     }
   }, [dataProvider, notify, invalidate]);
 
@@ -297,8 +317,28 @@ const GoogleConnectorCard = () => {
                 label="Synchroniser les contacts Google"
                 description="Importer vos contacts Google dans le CRM (correspondance par email)"
                 checked={preferences.syncContacts}
-                onChange={(v) => handlePreferenceChange("syncContacts", v)}
+                onChange={async (v) => {
+                  await handlePreferenceChange("syncContacts", v);
+                  if (v) handleSyncContacts();
+                }}
               />
+              {preferences.syncContacts && (
+                <div className="ml-7">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleSyncContacts}
+                    disabled={syncing}
+                  >
+                    {syncing ? (
+                      <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                    ) : (
+                      <RefreshCw className="h-4 w-4 mr-1" />
+                    )}
+                    Synchroniser maintenant
+                  </Button>
+                </div>
+              )}
             </div>
           </>
         )}


### PR DESCRIPTION
## Summary
- Ajout de `syncGoogleContacts()` dans le data provider pour appeler l'edge function `google-contacts-sync`
- Le toggle "Synchroniser les contacts Google" déclenche maintenant une synchro automatique à l'activation
- Ajout d'un bouton "Synchroniser maintenant" pour resynchroniser manuellement

## Root cause
Le toggle ne faisait que sauvegarder une préférence, sans jamais appeler l'edge function backend.