### PR TITLE
Add opportunity count to Kanban column headers

### DIFF
--- a/src/components/atomic-crm/deals/DealColumn.tsx
+++ b/src/components/atomic-crm/deals/DealColumn.tsx
@@ -19,7 +19,7 @@ export const DealColumn = ({
     <div className="flex-1 pb-8">
       <div className="flex flex-col items-center">
         <h3 className="text-base font-medium">
-          {findDealLabel(dealStages, stage)}
+          {findDealLabel(dealStages, stage)} ({deals.length})
         </h3>
         <p className="text-sm text-muted-foreground">
           {totalAmount.toLocaleString("en-US", {


### PR DESCRIPTION
Each column now shows the number of deals in parentheses next to the stage label (e.g. "Gagné (17)", "Lead (20)").