### PR TITLE
security: enforce RLS on all public tables and revoke anon grants

### DIFF
--- a/scripts/security-diagnostics.sql
+++ b/scripts/security-diagnostics.sql
@@ -1,0 +1,129 @@
+-- Supabase security diagnostics
+-- Paste these snippets into the Supabase SQL Editor (one project at a time)
+-- to confirm RLS hygiene before and after applying
+-- migrations/20260408120000_enforce_rls_security.sql.
+--
+-- Purpose: detect schema drift between this repo and the production
+-- databases (project refs `kmtoziejeblhdggjghrx` and `vrnjdsxdkqmdfdcydlas`).
+
+-- 1. Tables with RLS DISABLED in the public schema.
+--    Should return zero rows after the enforcement migration runs.
+select schemaname, tablename, rowsecurity
+from pg_tables
+where schemaname = 'public'
+  and rowsecurity = false
+order by tablename;
+
+-- 2. Tables with RLS enabled but NO policies at all.
+--    Such tables are deny-all for authenticated/anon (only service_role
+--    can reach them). After our migration, the `deny_anon_all` restrictive
+--    policy is added everywhere, so this query reflects the policies that
+--    actually grant access.
+select c.relname as table_name
+from pg_class c
+join pg_namespace n on n.oid = c.relnamespace
+where n.nspname = 'public'
+  and c.relkind = 'r'
+  and not exists (
+    select 1
+    from pg_policies p
+    where p.schemaname = 'public'
+      and p.tablename = c.relname
+      and p.permissive = 'PERMISSIVE'  -- ignore the deny-all restrictive net
+  )
+order by c.relname;
+
+-- 3. Tables NOT declared in supabase/schemas/01_tables.sql
+--    (= drift introduced via Supabase Studio / external scripts).
+--    Compare this list against the canonical 12 tables of Atomic CRM.
+with declared(name) as (
+  values
+    ('companies'),
+    ('contacts'),
+    ('contact_notes'),
+    ('deals'),
+    ('deal_notes'),
+    ('sales'),
+    ('tags'),
+    ('tasks'),
+    ('configuration'),
+    ('favicons_excluded_domains'),
+    ('google_oauth_tokens'),
+    ('connector_preferences')
+)
+select c.relname as drifted_table
+from pg_class c
+join pg_namespace n on n.oid = c.relnamespace
+where n.nspname = 'public'
+  and c.relkind = 'r'
+  and c.relname not in (select name from declared)
+order by c.relname;
+
+-- 4. Privileges granted to the anon role on public relations.
+--    Should be empty after the enforcement migration.
+select grantee, table_schema, table_name, privilege_type
+from information_schema.role_table_grants
+where table_schema = 'public'
+  and grantee = 'anon'
+order by table_name, privilege_type;
+
+-- 5. Privileges granted to the anon role on public functions.
+--    Should be empty after the enforcement migration.
+select n.nspname as schema,
+       p.proname as function_name,
+       pg_get_function_identity_arguments(p.oid) as arguments
+from pg_proc p
+join pg_namespace n on n.oid = p.pronamespace
+where n.nspname = 'public'
+  and has_function_privilege('anon', p.oid, 'EXECUTE');
+
+-- 6. Storage buckets that are publicly readable without auth.
+--    Anything returned here is reachable through
+--    /storage/v1/object/public/<bucket>/<path> by anyone with the URL.
+select id, name, public, file_size_limit, allowed_mime_types
+from storage.buckets
+where public = true;
+
+-- 7. Activity on the drifted tables, to figure out which app writes to them.
+--    Run after some real traffic to see seq_scan / n_tup_ins counts.
+select relname,
+       n_tup_ins as inserts,
+       n_tup_upd as updates,
+       n_tup_del as deletes,
+       n_live_tup as live_rows,
+       seq_scan,
+       idx_scan
+from pg_stat_user_tables
+where schemaname = 'public'
+  and relname in (
+    'business_card_leads',
+    'crm_notifications',
+    'People',
+    'People_backup',
+    'Notes'
+  )
+order by relname;
+
+-- 8. Foreign keys to or from the drifted tables — gives hints about how
+--    they integrate with the rest of the schema.
+select conrelid::regclass as table_name,
+       conname            as constraint_name,
+       pg_get_constraintdef(c.oid) as definition
+from pg_constraint c
+where contype = 'f'
+  and (
+    conrelid::regclass::text in (
+      'public."People"',
+      'public."People_backup"',
+      'public."Notes"',
+      'public.business_card_leads',
+      'public.crm_notifications'
+    )
+    or confrelid::regclass::text in (
+      'public."People"',
+      'public."People_backup"',
+      'public."Notes"',
+      'public.business_card_leads',
+      'public.crm_notifications'
+    )
+  );

--- a/supabase/migrations/20260408120000_enforce_rls_security.sql
+++ b/supabase/migrations/20260408120000_enforce_rls_security.sql
@@ -1,0 +1,119 @@
+-- Enforce Row Level Security on every table in the public schema and revoke
+-- the blanket privileges currently granted to the anon role.
+--
+-- Background: the Supabase Advisor flagged `rls_disabled_in_public` on tables
+-- that were created out-of-band (via the SQL Editor) and never enforced RLS:
+--   * business_card_leads  -> no RLS, no policies
+--   * crm_notifications    -> no RLS, no policies
+--   * "People_backup"      -> no RLS, no policies (PII backup, very sensitive)
+--   * "People"             -> RLS enabled but no policies (defaults to deny-all)
+--   * "Notes"              -> RLS enabled but no policies (defaults to deny-all)
+--
+-- Combined with the `grant all on table public.* to anon` declared in
+-- supabase/schemas/06_grants.sql, any table without RLS becomes fully readable
+-- and writable through the public anon key.
+--
+-- This migration is intentionally idempotent and defensive: it does NOT
+-- assume which tables exist, so it also covers any future drift.
+--
+-- IMPORTANT: enabling RLS on a table that has no policies denies access to
+-- the `authenticated` and `anon` roles. The `service_role` always bypasses
+-- RLS, so backend integrations using the service role key keep working.
+-- If a Make.com / n8n / external flow currently reads or writes one of the
+-- drifted tables with the anon key, that flow MUST be migrated to the
+-- service role key (or be granted an explicit policy) before this migration
+-- ships to production.
+
+-- 1. Enable (and force) RLS on every base table in public.
+do $$
+declare
+  r record;
+begin
+  for r in
+    select c.relname
+    from pg_class c
+    join pg_namespace n on n.oid = c.relnamespace
+    where n.nspname = 'public'
+      and c.relkind = 'r'
+  loop
+    execute format('alter table public.%I enable row level security;', r.relname);
+    execute format('alter table public.%I force row level security;', r.relname);
+  end loop;
+end $$;
+
+-- 2. Revoke the blanket privileges granted to anon on every public relation.
+--    The application uses the `authenticated` role exclusively from the browser
+--    and `service_role` from edge functions; anon should never touch tables.
+do $$
+declare
+  r record;
+begin
+  for r in
+    select c.relname
+    from pg_class c
+    join pg_namespace n on n.oid = c.relnamespace
+    where n.nspname = 'public'
+      and c.relkind in ('r', 'v', 'm', 'p')
+  loop
+    execute format('revoke all on table public.%I from anon;', r.relname);
+  end loop;
+end $$;
+
+-- Sequences: also drop the implicit anon access (we never use auto-id from anon).
+do $$
+declare
+  r record;
+begin
+  for r in
+    select c.relname
+    from pg_class c
+    join pg_namespace n on n.oid = c.relnamespace
+    where n.nspname = 'public'
+      and c.relkind = 'S'
+  loop
+    execute format('revoke all on sequence public.%I from anon;', r.relname);
+  end loop;
+end $$;
+
+-- Functions: drop EXECUTE from anon on every public function. Trigger
+-- functions only need to be callable by the role doing the DML, so revoking
+-- from anon is safe.
+do $$
+declare
+  r record;
+begin
+  for r in
+    select p.oid::regprocedure::text as sig
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'public'
+  loop
+    execute format('revoke all on function %s from anon;', r.sig);
+  end loop;
+end $$;
+
+-- 3. Stop auto-granting future tables / sequences / functions to anon.
+alter default privileges for role postgres in schema public revoke all on tables    from anon;
+alter default privileges for role postgres in schema public revoke all on sequences from anon;
+alter default privileges for role postgres in schema public revoke all on functions from anon;
+
+-- 4. Belt-and-braces deny policy: even if someone re-grants anon by mistake,
+--    a RESTRICTIVE policy ensures the anon role still cannot read or write.
+do $$
+declare
+  r record;
+begin
+  for r in
+    select c.relname
+    from pg_class c
+    join pg_namespace n on n.oid = c.relnamespace
+    where n.nspname = 'public'
+      and c.relkind = 'r'
+  loop
+    execute format('drop policy if exists "deny_anon_all" on public.%I;', r.relname);
+    execute format(
+      'create policy "deny_anon_all" on public.%I as restrictive for all to anon using (false) with check (false);',
+      r.relname
+    );
+  end loop;
+end $$;

--- a/supabase/schemas/06_grants.sql
+++ b/supabase/schemas/06_grants.sql
@@ -4,170 +4,144 @@
 --
 
 -- Schema usage
+-- Note: anon retains USAGE on the schema (required so PostgREST can resolve
+-- relation names) but never receives privileges on the relations themselves.
+-- See migrations/20260408120000_enforce_rls_security.sql.
 grant usage on schema public to postgres;
 grant usage on schema public to anon;
 grant usage on schema public to authenticated;
 grant usage on schema public to service_role;
 
 -- Function grants
-grant all on function public.cleanup_note_attachments() to anon;
+-- The anon role is never granted EXECUTE: triggers fire under the role that
+-- performed the DML, which is `authenticated` in normal operation, and edge
+-- functions run as `service_role`. Internal trigger functions therefore only
+-- need to be reachable from authenticated/service_role.
 grant all on function public.cleanup_note_attachments() to authenticated;
 grant all on function public.cleanup_note_attachments() to service_role;
 
-grant all on function public.get_avatar_for_email(text) to anon;
 grant all on function public.get_avatar_for_email(text) to authenticated;
 grant all on function public.get_avatar_for_email(text) to service_role;
 
-grant all on function public.get_domain_favicon(text) to anon;
 grant all on function public.get_domain_favicon(text) to authenticated;
 grant all on function public.get_domain_favicon(text) to service_role;
 
-grant all on function public.get_note_attachments_function_url() to anon;
 grant all on function public.get_note_attachments_function_url() to authenticated;
 grant all on function public.get_note_attachments_function_url() to service_role;
 
 revoke all on function public.get_user_id_by_email(text) from public;
 grant all on function public.get_user_id_by_email(text) to service_role;
 
-grant all on function public.handle_company_saved() to anon;
 grant all on function public.handle_company_saved() to authenticated;
 grant all on function public.handle_company_saved() to service_role;
 
-grant all on function public.handle_contact_note_created_or_updated() to anon;
 grant all on function public.handle_contact_note_created_or_updated() to authenticated;
 grant all on function public.handle_contact_note_created_or_updated() to service_role;
 
-grant all on function public.handle_contact_saved() to anon;
 grant all on function public.handle_contact_saved() to authenticated;
 grant all on function public.handle_contact_saved() to service_role;
 
-grant all on function public.handle_new_user() to anon;
 grant all on function public.handle_new_user() to authenticated;
 grant all on function public.handle_new_user() to service_role;
 
-grant all on function public.handle_update_user() to anon;
 grant all on function public.handle_update_user() to authenticated;
 grant all on function public.handle_update_user() to service_role;
 
-grant all on function public.is_admin() to anon;
 grant all on function public.is_admin() to authenticated;
 grant all on function public.is_admin() to service_role;
 
-grant all on function public.merge_contacts(bigint, bigint) to anon;
 grant all on function public.merge_contacts(bigint, bigint) to authenticated;
 grant all on function public.merge_contacts(bigint, bigint) to service_role;
 
-grant all on function public.set_sales_id_default() to anon;
 grant all on function public.set_sales_id_default() to authenticated;
 grant all on function public.set_sales_id_default() to service_role;
 
 -- Table grants
-grant all on table public.companies to anon;
+-- The anon role intentionally receives NO table privileges. Browser clients
+-- authenticate before reading data; unauthenticated public access is blocked
+-- both at the privilege layer and by the `deny_anon_all` RLS policy declared
+-- in migrations/20260408120000_enforce_rls_security.sql.
 grant all on table public.companies to authenticated;
 grant all on table public.companies to service_role;
 
-grant all on table public.contacts to anon;
 grant all on table public.contacts to authenticated;
 grant all on table public.contacts to service_role;
 
-grant all on table public.contact_notes to anon;
 grant all on table public.contact_notes to authenticated;
 grant all on table public.contact_notes to service_role;
 
-grant all on table public.deals to anon;
 grant all on table public.deals to authenticated;
 grant all on table public.deals to service_role;
 
-grant all on table public.deal_notes to anon;
 grant all on table public.deal_notes to authenticated;
 grant all on table public.deal_notes to service_role;
 
-grant all on table public.sales to anon;
 grant all on table public.sales to authenticated;
 grant all on table public.sales to service_role;
 
-grant all on table public.tags to anon;
 grant all on table public.tags to authenticated;
 grant all on table public.tags to service_role;
 
-grant all on table public.tasks to anon;
 grant all on table public.tasks to authenticated;
 grant all on table public.tasks to service_role;
 
-grant all on table public.configuration to anon;
 grant all on table public.configuration to authenticated;
 grant all on table public.configuration to service_role;
 
-grant all on table public.favicons_excluded_domains to anon;
 grant all on table public.favicons_excluded_domains to authenticated;
 grant all on table public.favicons_excluded_domains to service_role;
 
 -- View grants
-grant all on table public.activity_log to anon;
 grant all on table public.activity_log to authenticated;
 grant all on table public.activity_log to service_role;
 
-grant all on table public.companies_summary to anon;
 grant all on table public.companies_summary to authenticated;
 grant all on table public.companies_summary to service_role;
 
-grant all on table public.contacts_summary to anon;
 grant all on table public.contacts_summary to authenticated;
 grant all on table public.contacts_summary to service_role;
 
-grant all on table public.init_state to anon;
 grant all on table public.init_state to authenticated;
 grant all on table public.init_state to service_role;
 
 -- Sequence grants
-grant all on sequence public.companies_id_seq to anon;
 grant all on sequence public.companies_id_seq to authenticated;
 grant all on sequence public.companies_id_seq to service_role;
 
-grant all on sequence public."contactNotes_id_seq" to anon;
 grant all on sequence public."contactNotes_id_seq" to authenticated;
 grant all on sequence public."contactNotes_id_seq" to service_role;
 
-grant all on sequence public.contacts_id_seq to anon;
 grant all on sequence public.contacts_id_seq to authenticated;
 grant all on sequence public.contacts_id_seq to service_role;
 
-grant all on sequence public."dealNotes_id_seq" to anon;
 grant all on sequence public."dealNotes_id_seq" to authenticated;
 grant all on sequence public."dealNotes_id_seq" to service_role;
 
-grant all on sequence public.deals_id_seq to anon;
 grant all on sequence public.deals_id_seq to authenticated;
 grant all on sequence public.deals_id_seq to service_role;
 
-grant all on sequence public.favicons_excluded_domains_id_seq to anon;
 grant all on sequence public.favicons_excluded_domains_id_seq to authenticated;
 grant all on sequence public.favicons_excluded_domains_id_seq to service_role;
 
-grant all on sequence public.sales_id_seq to anon;
 grant all on sequence public.sales_id_seq to authenticated;
 grant all on sequence public.sales_id_seq to service_role;
 
-grant all on sequence public.tags_id_seq to anon;
 grant all on sequence public.tags_id_seq to authenticated;
 grant all on sequence public.tags_id_seq to service_role;
 
-grant all on sequence public.tasks_id_seq to anon;
 grant all on sequence public.tasks_id_seq to authenticated;
 grant all on sequence public.tasks_id_seq to service_role;
 
 -- Default privileges
+-- New tables / sequences / functions never auto-grant anything to anon.
 alter default privileges for role postgres in schema public grant all on sequences to postgres;
-alter default privileges for role postgres in schema public grant all on sequences to anon;
 alter default privileges for role postgres in schema public grant all on sequences to authenticated;
 alter default privileges for role postgres in schema public grant all on sequences to service_role;
 
 alter default privileges for role postgres in schema public grant all on functions to postgres;
-alter default privileges for role postgres in schema public grant all on functions to anon;
 alter default privileges for role postgres in schema public grant all on functions to authenticated;
 alter default privileges for role postgres in schema public grant all on functions to service_role;
 
 alter default privileges for role postgres in schema public grant all on tables to postgres;
-alter default privileges for role postgres in schema public grant all on tables to anon;
 alter default privileges for role postgres in schema public grant all on tables to authenticated;
 alter default privileges for role postgres in schema public grant all on tables to service_role;


### PR DESCRIPTION
## Pourquoi

Le Supabase Advisor remonte `rls_disabled_in_public` sur les projets `kmtoziejeblhdggjghrx` et `vrnjdsxdkqmdfdcydlas`. Diagnostic via `pg_tables` (cf. screenshots dans le ticket) :

| Table | RLS | Policies | Risque |
|---|---|---|---|
| `business_card_leads` | ❌ | n/a | 🔴 lecture/écriture publique via clé anon |
| `crm_notifications` | ❌ | ❌ | 🔴 idem |
| `"People_backup"` | ❌ | ❌ | 🔴 backup PII publique |
| `"People"` | ✅ | ❌ | 🟡 deny-all par défaut |
| `"Notes"` | ✅ | ❌ | 🟡 deny-all par défaut |

Aucune de ces tables n'existe dans `supabase/schemas/` ou `supabase/migrations/` — elles ont été créées hors-tree (SQL Editor / autre app). Combiné aux `grant all on table public.* to anon` du `06_grants.sql`, n'importe quelle table sans RLS est totalement exposée via la clé anon.

## Ce que fait ce PR

### `supabase/migrations/20260408120000_enforce_rls_security.sql`
Idempotent et défensif (boucles dynamiques sur `pg_class`, donc couvre aussi les futures dérives) :
1. `enable + force row level security` sur **toutes** les tables base de `public`
2. `revoke all` sur tables / vues / séquences / fonctions pour le rôle `anon`
3. `alter default privileges … revoke … from anon` → les futurs objets ne re-héritent plus de privilèges anon
4. Policy `restrictive deny_anon_all` posée sur chaque table comme filet de sécurité

### `supabase/schemas/06_grants.sql`
Nettoyé de tous les `to anon` (sinon le prochain `db diff` régénère le problème). `usage on schema public to anon` est conservé — requis par PostgREST pour résoudre les noms de relations.

### `scripts/security-diagnostics.sql`
8 requêtes prêtes à coller dans le SQL Editor pour auditer en continu :
- tables sans RLS
- tables sans policies permissives
- tables drift par rapport au schéma déclaratif
- privilèges anon résiduels (tables + fonctions)
- buckets storage publics
- activité et FK des tables drift identifiées

## Impact

✅ **service_role** bypass RLS → toutes les Edge Functions et intégrations server-side continuent de fonctionner
✅ **authenticated** : aucun changement (les policies existantes utilisent déjà `to authenticated`)
⚠️ **anon** : tout accès table coupé. Si une intégration externe (Make / n8n / form public) écrit dans `business_card_leads` ou `crm_notifications` avec la clé anon, elle cassera et devra passer à la `service_role` ou recevoir une policy explicite.

## Test plan

- [ ] CI verte (`make test`, `make typecheck`, `make lint`)
- [ ] `npx supabase db push` sur **les deux projets** (le workflow pousse uniquement `SUPABASE_PROJECT_ID`, l'autre est manuel)
- [ ] Vérifier post-deploy via `scripts/security-diagnostics.sql` requêtes 1, 4, 5 → doivent retourner 0 ligne
- [ ] Smoke test app : login, lecture liste contacts/deals/companies, création contact, ajout note
- [ ] Vérifier que les flows Postmark / Google Calendar / enrichissements continuent de tourner (ils utilisent `service_role`)

## Suite

- `claude/private-attachments-bucket` (à venir) — passer le bucket `attachments` en privé + URLs signées
- Décision produit : cloisonnement multi-tenant par `sales_id` sur `companies/contacts/deals/...` (aujourd'hui chaque user authentifié voit toute la base)
- Identifier l'app source des tables drift pour les rapatrier dans `01_tables.sql` ou les déplacer dans un schéma dédié