### PR TITLE
security: privatize attachments bucket and resolve signed URLs at read time

### DIFF
--- a/src/components/atomic-crm/providers/supabase/dataProvider.ts
+++ b/src/components/atomic-crm/providers/supabase/dataProvider.ts
@@ -7,6 +7,7 @@ import {
   type ResourceCallbacks,
 } from "ra-core";
 import type {
+  AttachmentNote,
   ContactNote,
   Deal,
   DealNote,
@@ -399,7 +400,9 @@ const getDataProviderWithCustomMethods = () => {
   } satisfies DataProvider;
 };
 
-export type CrmDataProvider = ReturnType<typeof getDataProviderWithCustomMethods>;
+export type CrmDataProvider = ReturnType<
+  typeof getDataProviderWithCustomMethods
+>;
 
 const processConfigLogo = async (logo: any): Promise<string> => {
   if (typeof logo === "string") return logo;
@@ -432,6 +435,10 @@ const lifeCycleCallbacks: ResourceCallbacks[] = [
       }
       return data;
     },
+    afterRead: async (record) => {
+      await resolveRecordAttachments(record);
+      return record;
+    },
   },
   {
     resource: "deal_notes",
@@ -443,6 +450,10 @@ const lifeCycleCallbacks: ResourceCallbacks[] = [
       }
       return data;
     },
+    afterRead: async (record) => {
+      await resolveRecordAttachments(record);
+      return record;
+    },
   },
   {
     resource: "sales",
@@ -451,6 +462,10 @@ const lifeCycleCallbacks: ResourceCallbacks[] = [
         await uploadToBucket(data.avatar);
       }
       return data;
+    },
+    afterRead: async (record) => {
+      await resolveRecordAttachments(record);
+      return record;
     },
   },
   {
@@ -497,11 +512,9 @@ const lifeCycleCallbacks: ResourceCallbacks[] = [
   {
     resource: "contacts_summary",
     beforeGetList: async (params) => {
-      return applyFullTextSearch([
-        "first_name",
-        "last_name",
-        "company_name",
-      ])(params);
+      return applyFullTextSearch(["first_name", "last_name", "company_name"])(
+        params,
+      );
     },
   },
   {
@@ -598,18 +611,113 @@ const applyFullTextSearch = (columns: string[]) => (params: GetListParams) => {
   };
 };
 
+// How long signed URLs minted for the attachments bucket remain valid.
+// One hour is enough for a normal session of viewing notes / images and
+// short enough that a leaked URL stops working quickly. Re-signing happens
+// transparently on every read via the lifecycle callbacks below.
+const SIGNED_URL_TTL_SECONDS = 60 * 60;
+
+/**
+ * Builds a fresh, short-lived signed URL for an attachment stored in the
+ * private `attachments` bucket.
+ *
+ * Returns `null` when the storage path cannot be resolved (legacy record
+ * with neither `path` nor a recognizable storage URL in `src`, or storage
+ * itself errored). Callers must keep the original `src` in that case so
+ * external URLs (gravatar, favicons, ...) keep working.
+ */
+const signAttachmentUrl = async (
+  storagePath: string,
+): Promise<string | null> => {
+  const { data, error } = await getSupabaseClient()
+    .storage.from(ATTACHMENTS_BUCKET)
+    .createSignedUrl(storagePath, SIGNED_URL_TTL_SECONDS);
+
+  if (error || !data?.signedUrl) {
+    console.warn("Failed to sign attachment URL", { storagePath, error });
+    return null;
+  }
+  return data.signedUrl;
+};
+
+/**
+ * Returns the storage path for a file that lives in the `attachments`
+ * bucket, or `null` if it does not (e.g. external URL like gravatar.com).
+ *
+ * Strategy:
+ *   1. Prefer the explicit `path` set by `uploadToBucket` for new uploads.
+ *   2. For legacy records persisted before we stopped storing public URLs,
+ *      parse the `src` and extract the trailing path segment.
+ */
+const getAttachmentStoragePath = (file: Partial<RAFile>): string | null => {
+  if (file.path) return file.path;
+  if (!file.src) return null;
+  // Match both legacy public URLs and previously-signed URLs:
+  //   /storage/v1/object/public/attachments/<path>
+  //   /storage/v1/object/sign/attachments/<path>?token=...
+  const match = file.src.match(
+    /\/storage\/v1\/object\/(?:public|sign|authenticated)\/attachments\/([^?]+)/,
+  );
+  if (!match) return null;
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return match[1];
+  }
+};
+
+/**
+ * Resolves an attachment in place: replaces `src` with a fresh signed URL
+ * derived from its storage path, leaving external URLs untouched.
+ */
+const resolveAttachmentInPlace = async <T extends Partial<RAFile>>(
+  file: T | null | undefined,
+): Promise<T | null | undefined> => {
+  if (!file) return file;
+  const storagePath = getAttachmentStoragePath(file);
+  if (!storagePath) return file;
+  const signedUrl = await signAttachmentUrl(storagePath);
+  if (signedUrl) {
+    file.src = signedUrl;
+    if (!file.path) file.path = storagePath;
+  }
+  return file;
+};
+
+/**
+ * Resolves every attachment of a single record (note, sale, ...). Mutates
+ * the record in place to keep the lifecycle hooks lightweight.
+ */
+const resolveRecordAttachments = async (record: any): Promise<void> => {
+  if (!record) return;
+  if (Array.isArray(record.attachments)) {
+    await Promise.all(
+      record.attachments.map((attachment: AttachmentNote) =>
+        resolveAttachmentInPlace(attachment),
+      ),
+    );
+  }
+  if (record.avatar) {
+    await resolveAttachmentInPlace(record.avatar);
+  }
+  if (record.logo) {
+    await resolveAttachmentInPlace(record.logo);
+  }
+};
+
 const uploadToBucket = async (fi: RAFile) => {
   if (!fi.src.startsWith("blob:") && !fi.src.startsWith("data:")) {
-    // Sign URL check if path exists in the bucket
+    // Already-uploaded file: nothing to do, the read-side lifecycle hook
+    // will mint a fresh signed URL on the next fetch.
     if (fi.path) {
-      const { error } = await getSupabaseClient()
-        .storage
-        .from(ATTACHMENTS_BUCKET)
-        .createSignedUrl(fi.path, 60);
-
-      if (!error) {
-        return fi;
-      }
+      return fi;
+    }
+    // Legacy record without `path`: derive it from the persisted URL when
+    // possible so future reads can re-sign without re-uploading.
+    const derivedPath = getAttachmentStoragePath(fi);
+    if (derivedPath) {
+      fi.path = derivedPath;
+      return fi;
     }
   }
 
@@ -635,11 +743,13 @@ const uploadToBucket = async (fi: RAFile) => {
   const file = fi.rawFile;
   const fileParts = file.name.split(".");
   const fileExt = fileParts.length > 1 ? `.${file.name.split(".").pop()}` : "";
-  const fileName = `${Math.random()}${fileExt}`;
+  // Use crypto.randomUUID() instead of Math.random(): the previous scheme
+  // produced filenames like `0.123456789.pdf` with only ~52 bits of entropy,
+  // which made the bucket vulnerable to URL enumeration when it was public.
+  const fileName = `${crypto.randomUUID()}${fileExt}`;
   const filePath = `${fileName}`;
   const { error: uploadError } = await getSupabaseClient()
-    .storage
-    .from(ATTACHMENTS_BUCKET)
+    .storage.from(ATTACHMENTS_BUCKET)
     .upload(filePath, dataContent);
 
   if (uploadError) {
@@ -647,13 +757,15 @@ const uploadToBucket = async (fi: RAFile) => {
     throw new Error("Failed to upload attachment");
   }
 
-  const { data } = getSupabaseClient()
-    .storage
-    .from(ATTACHMENTS_BUCKET)
-    .getPublicUrl(filePath);
-
   fi.path = filePath;
-  fi.src = data.publicUrl;
+
+  // Mint a short-lived signed URL so the freshly uploaded file is
+  // immediately viewable in the form. Subsequent fetches go through the
+  // afterRead lifecycle hooks which always re-sign.
+  const signedUrl = await signAttachmentUrl(filePath);
+  if (signedUrl) {
+    fi.src = signedUrl;
+  }
 
   // save MIME type
   const mimeType = file.type;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "v1.9.25";
+export const APP_VERSION = "v1.9.26";

--- a/supabase/functions/postmark/extractAndUploadAttachments.ts
+++ b/supabase/functions/postmark/extractAndUploadAttachments.ts
@@ -5,13 +5,22 @@ export type Attachment = {
   title: string;
   type: string;
   path: string;
+  // `src` is intentionally left empty when persisting: the attachments
+  // bucket is private (see migrations/20260408140000_attachments_bucket_private.sql)
+  // and the frontend re-mints a short-lived signed URL on every read via
+  // the `afterRead` lifecycle hook in `dataProvider.ts`. We keep the field
+  // for shape compatibility with the existing JSONB column.
   src: string;
 };
 
 /**
- * Extracts the attachments from the email and upload them to Supabase Storage.
+ * Extracts the attachments from a Postmark inbound email payload and uploads
+ * them to the private `attachments` bucket on Supabase Storage.
  *
- * Example:
+ * Each returned attachment carries only the storage `path`; the matching
+ * frontend code resolves it to a fresh signed URL at read time.
+ *
+ * Example input:
  *   "Attachments": [
  *      {
  *          "Name": "test.txt",
@@ -21,14 +30,13 @@ export type Attachment = {
  *      }
  *   ]
  *
- * Return Value:
- * [{
- *    title: "test.txt",
- *    type: "text/plain",
- *    "path": "0.8262106278726917.txt",
- *    "src": "http://127.0.0.1:54321/storage/v1/object/public/attachments/0.8262106278726917.txt",
- * }]
- *
+ * Returned shape:
+ *   [{
+ *      title: "test.txt",
+ *      type: "text/plain",
+ *      path: "9b2c…uuid….txt",
+ *      src: "",
+ *   }]
  */
 export const extractAndUploadAttachments = async (
   Attachments: {
@@ -59,7 +67,10 @@ export const extractAndUploadAttachments = async (
 
         const fileParts = Name.split(".");
         const fileExt = fileParts.length > 1 ? `.${Name.split(".").pop()}` : "";
-        const fileName = `${Math.random()}${fileExt}`;
+        // crypto.randomUUID() gives 122 bits of entropy, replacing the old
+        // Math.random()-based filenames that were enumerable when the bucket
+        // was still public.
+        const fileName = `${crypto.randomUUID()}${fileExt}`;
         const { error: uploadError } = await supabaseAdmin.storage
           .from("attachments")
           .upload(fileName, decodedContent);
@@ -69,29 +80,13 @@ export const extractAndUploadAttachments = async (
           throw new Error("Failed to upload attachment");
         }
 
-        const { data } = supabaseAdmin.storage
-          .from("attachments")
-          .getPublicUrl(fileName);
-
         return {
           title: Name,
           type: ContentType,
           path: fileName,
-          src: fixPublicUrl(data.publicUrl),
+          src: "",
         };
       }),
     )
   ).filter(Boolean) as Attachment[];
-};
-
-/*
- * Workaround fix for public URL not working on local environment
- * See https://github.com/orgs/supabase/discussions/37271
- *
- * Replaces http://kong:8000/storage/v1/object/public/attachments/0.08968261048718773.txt with http://127.0.0.1:54321/storage/v1/object/public/attachments/0.08968261048718773.txt, using the SB_JWT_ISSUER env var (value http://127.0.0.1:54321/auth/v1) to get the external/public URL of the Supabase instance.
- */
-const fixPublicUrl = (url: string) => {
-  const jwtIssuer = Deno.env.get("SB_JWT_ISSUER") ?? "";
-  const localUrl = jwtIssuer.replace("/auth/v1", "");
-  return url.replace("http://kong:8000", localUrl);
 };

--- a/supabase/migrations/20260408140000_attachments_bucket_private.sql
+++ b/supabase/migrations/20260408140000_attachments_bucket_private.sql
@@ -1,0 +1,26 @@
+-- Switch the `attachments` storage bucket from public to private.
+--
+-- Background: the bucket has been declared `public = true` since
+-- migrations/20240730075029_init_db.sql, which means every uploaded file is
+-- reachable through `/storage/v1/object/public/attachments/<filename>` by
+-- anyone who guesses the URL — and filenames were generated with
+-- `Math.random()`, which has only ~52 bits of entropy.
+--
+-- After this migration:
+-- * the bucket is private; reads require either an authenticated session
+--   that satisfies the existing storage.objects RLS policies, or a signed
+--   URL minted server-side.
+-- * the frontend resolves attachments to short-lived signed URLs at read
+--   time inside `dataProvider.ts` (see the `signAttachmentInPlace` helper
+--   added in the same PR).
+-- * historical rows whose `attachments[].path` is missing fall back to
+--   extracting the path from the persisted public URL — handled in the
+--   frontend, no destructive backfill needed.
+--
+-- The existing INSERT/SELECT/DELETE policies on `storage.objects` for the
+-- `attachments` bucket already restrict to `authenticated`, so making the
+-- bucket private only removes the public-URL escape hatch.
+
+update storage.buckets
+set public = false
+where id = 'attachments';


### PR DESCRIPTION
## Pourquoi

Le bucket `attachments` est `public = true` depuis la toute première migration (`20240730075029_init_db.sql`). Concrètement :

1. Toute pièce jointe uploadée via le CRM est lisible sans authentification à `https://xxx.supabase.co/storage/v1/object/public/attachments/<filename>`
2. Les noms de fichier sont générés avec `Math.random()` (~52 bits d'entropie) → énumérables en quelques heures avec un script
3. Idem côté webhook Postmark (emails entrants) qui stocke aussi les URLs publiques

Risque réel d'exfiltration sur les notes (`contact_notes`/`deal_notes`), avatars `sales`, etc. Le hardening RLS de #14 ne couvre pas ce vecteur — c'est storage, pas RLS table.

## Ce que fait ce PR

### Migration `supabase/migrations/20260408140000_attachments_bucket_private.sql`
```sql
update storage.buckets set public = false where id = 'attachments';
```
Les policies RLS existantes sur `storage.objects` (déjà en place dans `07_storage.sql`) restreignent déjà SELECT/INSERT/DELETE à `authenticated`. Privatiser ne fait que supprimer la fuite par URL publique.

### Filename generation
`Math.random()` → `crypto.randomUUID()` dans :
- `src/components/atomic-crm/providers/supabase/dataProvider.ts:uploadToBucket`
- `supabase/functions/postmark/extractAndUploadAttachments.ts`

122 bits d'entropie, plus brute-forçables.

### Trois helpers ajoutés dans `dataProvider.ts`
- **`signAttachmentUrl(path)`** — mint une URL signée TTL 1h
- **`getAttachmentStoragePath(file)`** — préfère `file.path` ; sinon parse `file.src` pour en extraire le path (compat. records legacy persistés avec une URL publique)
- **`resolveAttachmentInPlace(file)`** — remplace `src` par une URL signée fraîche, laisse passer les URLs externes (gravatar, favicons)

### `afterRead` lifecycle callbacks
Enregistrés sur `contact_notes`, `deal_notes`, `sales`. Chaque record fetch passe par `resolveRecordAttachments` qui re-signe les `attachments[]`, le `avatar` et le `logo`.

### `uploadToBucket`
Ne persiste plus `getPublicUrl()` → stocke uniquement `path` et mint un signed URL court pour la preview immédiate post-upload. Les lectures suivantes passent par le lifecycle hook.

### Postmark `extractAndUploadAttachments.ts`
Stocke `path` uniquement, `src: ""`. Le helper `fixPublicUrl` (workaround kong:8000 → localhost) est supprimé puisque plus utilisé.

## Backfill

**Pas de migration de données nécessaire.** Les anciens records dont `attachments[].path` n'a jamais été persisté seront résolus à la volée par `getAttachmentStoragePath` qui parse l'URL publique stockée dans `src` :

```regex
/storage/v1/object/(?:public|sign|authenticated)/attachments/<path>
```

→ extraction du path → signature → remplacement de `src`. Idempotent et sans toucher la base.

## Hors scope (à faire dans un PR séparé)

- `companies.logo` — souvent un favicon externe (`handle_company_saved` trigger), parfois un upload manuel. Le résoudre en signed URL nécessite de distinguer les deux cas dans l'`afterRead` companies.
- `configuration.config.lightModeLogo` / `darkModeLogo` — uploadés via `processConfigLogo`, mêmes considérations.
- Reportes éventuels Sentry / dashboards externes qui hotlinkent des PJ → vont casser, à valider côté ops.

## Test plan

- [x] `npx tsc --noEmit` propre
- [x] `npx prettier --check` propre sur les fichiers touchés
- [x] `npx eslint` propre sur les fichiers touchés
- [ ] Smoke test post-deploy : upload note avec PJ image → preview immédiate OK
- [ ] Smoke test post-deploy : recharger une note existante avec PJ → image visible (signed URL)
- [ ] Smoke test post-deploy : webhook Postmark → email entrant avec PJ → note créée → PJ visible
- [ ] Vérifier dans le storage que les nouveaux fichiers ont des noms UUID (pas `0.xxxxxx`)
- [ ] Vérifier qu'une URL publique brute renvoie 400/401 après le passage en privé

⚠️ **Coordination déploiement** : la migration et le code frontend doivent être déployés ensemble. Si le bucket bascule en privé avant que le code dataProvider soit live, toutes les images de notes se cassent jusqu'au déploiement frontend.