### PR TITLE
security: resolve company logo and configuration logos to signed URLs

### DIFF
--- a/src/components/atomic-crm/providers/supabase/dataProvider.ts
+++ b/src/components/atomic-crm/providers/supabase/dataProvider.ts
@@ -270,7 +270,18 @@ const getDataProviderWithCustomMethods = () => {
       const { data } = await baseDataProvider.getOne("configuration", {
         id: 1,
       });
-      return (data?.config as ConfigurationContextValue) ?? {};
+      const config = (data?.config as ConfigurationContextValue) ?? {};
+      // This call goes through the bare base provider, so the `afterRead`
+      // lifecycle hook on `configuration` is bypassed. Resolve logos
+      // manually so the bootstrap path (CRM.tsx, useConfigurationLoader)
+      // doesn't end up rendering expired or unsigned storage paths.
+      if (config.lightModeLogo != null) {
+        config.lightModeLogo = await resolveConfigLogo(config.lightModeLogo);
+      }
+      if (config.darkModeLogo != null) {
+        config.darkModeLogo = await resolveConfigLogo(config.darkModeLogo);
+      }
+      return config;
     },
     async updateConfiguration(
       config: ConfigurationContextValue,
@@ -404,13 +415,57 @@ export type CrmDataProvider = ReturnType<
   typeof getDataProviderWithCustomMethods
 >;
 
+/**
+ * Persists a configuration logo and returns the storage path (or external
+ * URL) that should be stored in the JSONB column.
+ *
+ * The previous implementation returned `logo.src`, which after the
+ * private-bucket migration is a 1h signed URL — that would expire in the
+ * database within an hour. We instead persist the durable storage `path`
+ * for uploaded files, and let the `afterRead` lifecycle hook on
+ * `configuration` mint a fresh signed URL on every read.
+ *
+ * Heuristic for the returned string:
+ *   * empty / nullish input → empty string
+ *   * existing string already in the DB → returned untouched (could be an
+ *     external URL, a legacy public attachments URL, or a new path; the
+ *     read-side resolver knows how to handle each case).
+ *   * RAFile with a rawFile → upload, return its newly assigned `path`.
+ *   * RAFile without rawFile → return `path` if known, else fall back to
+ *     `src` (legacy records).
+ */
 const processConfigLogo = async (logo: any): Promise<string> => {
+  if (logo == null) return "";
   if (typeof logo === "string") return logo;
   if (logo?.rawFile instanceof File) {
     await uploadToBucket(logo);
-    return logo.src;
+    return logo.path ?? logo.src ?? "";
   }
-  return logo?.src ?? "";
+  return logo?.path ?? logo?.src ?? "";
+};
+
+/**
+ * Resolves a configuration logo (stored as a plain string) to a URL the
+ * browser can render.
+ *
+ * Distinguishes three cases:
+ *   1. external URL (gravatar, favicon CDN, ...) → returned as-is.
+ *   2. legacy public attachments URL → extract path, mint signed URL.
+ *   3. new bare storage path → mint signed URL directly.
+ */
+const resolveConfigLogo = async (value: unknown): Promise<string> => {
+  if (typeof value !== "string" || value === "") return "";
+  if (value.startsWith("data:")) return value;
+  if (/^https?:\/\//i.test(value)) {
+    // Could be an external URL OR a legacy public-attachments URL.
+    const path = getAttachmentStoragePath({ src: value });
+    if (!path) return value;
+    const signed = await signAttachmentUrl(path);
+    return signed ?? value;
+  }
+  // Bare path → sign directly.
+  const signed = await signAttachmentUrl(value);
+  return signed ?? value;
 };
 
 const lifeCycleCallbacks: ResourceCallbacks[] = [
@@ -423,6 +478,17 @@ const lifeCycleCallbacks: ResourceCallbacks[] = [
         config.darkModeLogo = await processConfigLogo(config.darkModeLogo);
       }
       return params;
+    },
+    afterRead: async (record) => {
+      if (record?.config) {
+        record.config.lightModeLogo = await resolveConfigLogo(
+          record.config.lightModeLogo,
+        );
+        record.config.darkModeLogo = await resolveConfigLogo(
+          record.config.darkModeLogo,
+        );
+      }
+      return record;
     },
   },
   {
@@ -507,6 +573,14 @@ const lifeCycleCallbacks: ResourceCallbacks[] = [
     },
     beforeUpdate: async (params) => {
       return await processCompanyLogo(params);
+    },
+    // Resolve company.logo to a fresh signed URL on every read. Lifecycle
+    // hooks fire on the wrapper resource argument ("companies"), not on the
+    // underlying view ("companies_summary") that the custom getList/getOne
+    // forwards to, so we register here.
+    afterRead: async (record) => {
+      await resolveRecordAttachments(record);
+      return record;
     },
   },
   {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "v1.9.26";
+export const APP_VERSION = "v1.9.27";


### PR DESCRIPTION
## Pourquoi

Suite à #15 qui a privatisé le bucket `attachments`, deux surfaces d'attaque restaient ouvertes :

### 1. `company.logo` — re-signage manquant à la lecture

`processCompanyLogo` upload le fichier et persiste l'objet `RAFile` complet (`{ src, path, type, ... }`) dans la colonne JSONB `companies.logo`. Après #15, `src` contient une URL signée TTL 1h, donc :
- À l'instant T : OK
- À T+1h : URL expirée → image cassée jusqu'au prochain `update()`

J'ai analysé que l'`afterRead` doit s'enregistrer sur la resource **`companies`** (et pas `companies_summary`) parce que `withLifecycleCallbacks` dispatche sur l'argument resource passé par le caller : react-admin appelle `getList("companies", ...)`, le custom getList override forwarde en interne vers `baseDataProvider.getList("companies_summary", ...)` (provider brut, sans lifecycle), puis le wrapper fire `afterRead` pour `"companies"`.

### 2. `configuration.config.lightModeLogo` / `darkModeLogo` — bug critique introduit par #15

Ces logos sont persistés comme **strings** dans `configuration.config` (jsonb). Avant #15 c'était une URL publique permanente. Après #15, `processConfigLogo` retournait `logo.src` qui est désormais une URL signée TTL 1h → **stockée 1h dans la base, expirée pour tous les users après**.

Concrètement : un admin uploade un nouveau logo, ça marche pendant 1h, puis le branding casse pour tout le monde jusqu'au prochain re-upload.

## Ce que fait ce PR

### `processConfigLogo`
- Retourne désormais `logo.path` (durable) au lieu de `logo.src` (signed URL éphémère)
- Reste rétrocompatible avec les strings existantes (URL publique legacy ou URL externe)

### `resolveConfigLogo` (nouveau helper)
Heuristique sur la string stockée :
1. `data:` URI → renvoyé tel quel
2. `http(s)://` :
   - matche `/storage/v1/object/(public|sign|authenticated)/attachments/<path>` → extrait path → signe → renvoie signed URL
   - sinon → URL externe (gravatar, favicon CDN) → renvoyé tel quel
3. Bare path (UUID-like) → signe directement

### `afterRead` sur `configuration`
Résout `config.lightModeLogo` et `config.darkModeLogo` à chaque lecture passant par le wrapper (Edit page, useGetOne en composants).

### `afterRead` sur `companies`
Re-signe `record.logo` via `resolveRecordAttachments`. Couvre tous les fetches de la List/Show/Edit Companies.

### `getConfiguration()` — bypass lifecycle fixé manuellement
La méthode custom `getConfiguration()` appelle `baseDataProvider.getOne("configuration", ...)` directement (provider brut), donc le lifecycle hook ne fire pas pour ce path. Or c'est exactement le path utilisé par `useConfigurationLoader` et `CRM.tsx` au bootstrap de l'app — c'est lui qui hydrate le branding.

→ Ajout d'un appel explicite à `resolveConfigLogo` à la sortie de `getConfiguration()`.

## Backfill

**Pas de migration de données nécessaire.** Les trois shapes que la colonne peut contenir (URL externe, URL publique legacy, path brut) sont toutes gérées par `resolveConfigLogo` / `getAttachmentStoragePath`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx prettier --check` clean sur le fichier touché
- [x] `npx eslint` clean sur le fichier touché
- [ ] Smoke post-deploy : recharger le settings, vérifier que les logos light/dark s'affichent
- [ ] Smoke post-deploy : éditer un logo de société puis recharger la fiche, vérifier l'affichage
- [ ] Smoke post-deploy : attendre 1h après upload et recharger — vérifier qu'on a une nouvelle URL signée (et pas une 400)