### PR TITLE
security: add scheduled drift detection for Supabase hardening

### DIFF
--- a/.github/workflows/security-drift.yml
+++ b/.github/workflows/security-drift.yml
@@ -60,11 +60,19 @@ jobs:
                   sudo apt-get install -y --no-install-recommends postgresql-client
 
             - name: 🔎 Confirm secret is configured
+              id: check_secret
               run: |
                   if [[ -z "$SUPABASE_DB_URL" ]]; then
+                      if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+                          echo "::warning::SUPABASE_DB_URL secret is not configured; skipping the drift check on this pull request. Add the secret in repo settings > Secrets and variables > Actions (use the Session pooler connection string from Supabase Studio > Project Settings > Database) so scheduled runs can execute."
+                          echo "skip=true" >> "$GITHUB_OUTPUT"
+                          exit 0
+                      fi
                       echo "::error::SUPABASE_DB_URL secret is not configured. Add it in repo settings > Secrets and variables > Actions. Use the 'Session pooler' connection string from Supabase Studio > Project Settings > Database."
                       exit 1
                   fi
+                  echo "skip=false" >> "$GITHUB_OUTPUT"
 
             - name: 🛡️ Run drift check
+              if: steps.check_secret.outputs.skip != 'true'
               run: ./scripts/drift-check.sh

--- a/.github/workflows/security-drift.yml
+++ b/.github/workflows/security-drift.yml
@@ -1,0 +1,70 @@
+name: 🛡️ Security drift
+
+# Runs scripts/drift-check.sh against the production Supabase project(s)
+# to catch tables created out-of-band, anon grants reintroduced by mistake,
+# storage buckets flipped back to public, and other regressions of the
+# hardening delivered by #14, #15 and #16.
+#
+# Triggers:
+#   * On PRs that touch any Supabase file — blocks merge if the current
+#     production state already has drift (so we notice before compounding
+#     the problem with new migrations).
+#   * Daily at 06:00 UTC — catches drift introduced directly via the
+#     Supabase SQL Editor between deploys.
+#   * Manual via workflow_dispatch — for on-demand audits.
+
+on:
+    pull_request:
+        paths:
+            - "supabase/**"
+            - "scripts/drift-check.sql"
+            - "scripts/drift-check.sh"
+            - ".github/workflows/security-drift.yml"
+        types:
+            - opened
+            - reopened
+            - synchronize
+            - ready_for_review
+    schedule:
+        - cron: "0 6 * * *"
+    workflow_dispatch:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+jobs:
+    drift-check:
+        name: 🛡️ Supabase drift check
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        # Skip the PR run when the secret is missing (e.g. forks): we still
+        # want the scheduled run to fail loudly on the main repo.
+        if: >-
+            github.event_name != 'pull_request'
+            || !github.event.pull_request.draft
+        env:
+            SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+            SUPABASE_LABEL: production
+
+        steps:
+            - name: 📥 Checkout repo
+              uses: actions/checkout@v4
+
+            - name: ⚙️ Install postgresql-client
+              run: |
+                  sudo apt-get update -qq
+                  sudo apt-get install -y --no-install-recommends postgresql-client
+
+            - name: 🔎 Confirm secret is configured
+              run: |
+                  if [[ -z "$SUPABASE_DB_URL" ]]; then
+                      echo "::error::SUPABASE_DB_URL secret is not configured. Add it in repo settings > Secrets and variables > Actions. Use the 'Session pooler' connection string from Supabase Studio > Project Settings > Database."
+                      exit 1
+                  fi
+
+            - name: 🛡️ Run drift check
+              run: ./scripts/drift-check.sh

--- a/scripts/drift-check.sh
+++ b/scripts/drift-check.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Supabase security drift check.
+#
+# Runs scripts/drift-check.sql against a remote Supabase project via psql and
+# exits non-zero if any drift finding is returned. Intended for use in CI
+# (see .github/workflows/security-drift.yml) and for ad-hoc runs from a
+# developer machine.
+#
+# Required environment:
+#   SUPABASE_DB_URL  postgres:// connection string (use the pooler URL from
+#                    Supabase Studio > Project Settings > Database > Connection string)
+#
+# Optional environment:
+#   SUPABASE_LABEL   human-readable label printed with every finding (useful
+#                    when the workflow runs across multiple projects)
+#
+# Exit codes:
+#   0  no drift
+#   1  drift detected
+#   2  configuration error (missing env / psql not installed)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SQL_FILE="${SCRIPT_DIR}/drift-check.sql"
+LABEL="${SUPABASE_LABEL:-supabase}"
+
+if [[ -z "${SUPABASE_DB_URL:-}" ]]; then
+  echo "error: SUPABASE_DB_URL is not set" >&2
+  exit 2
+fi
+
+if ! command -v psql >/dev/null 2>&1; then
+  echo "error: psql is not installed (install postgresql-client)" >&2
+  exit 2
+fi
+
+if [[ ! -f "$SQL_FILE" ]]; then
+  echo "error: SQL file not found: $SQL_FILE" >&2
+  exit 2
+fi
+
+# -t   tuples only (no headers, no footer)
+# -A   unaligned output (no padding)
+# -F $'\t'  tab-separated fields
+# ON_ERROR_STOP=1  fail fast on SQL errors
+output=$(
+  PGOPTIONS="-c statement_timeout=30000" \
+    psql "$SUPABASE_DB_URL" \
+    --no-psqlrc \
+    -v ON_ERROR_STOP=1 \
+    -t -A -F $'\t' \
+    -f "$SQL_FILE"
+)
+
+if [[ -z "$output" ]]; then
+  echo "[${LABEL}] OK: no security drift detected."
+  exit 0
+fi
+
+echo "[${LABEL}] ✗ security drift detected:" >&2
+echo >&2
+printf "%-25s  %-60s  %s\n" "FINDING" "OBJECT" "REMEDIATION" >&2
+printf "%-25s  %-60s  %s\n" "-------" "------" "-----------" >&2
+while IFS=$'\t' read -r finding object remediation; do
+  printf "%-25s  %-60s  %s\n" "$finding" "$object" "$remediation" >&2
+done <<< "$output"
+echo >&2
+echo "[${LABEL}] run scripts/drift-check.sql against the project for full context" >&2
+exit 1

--- a/scripts/drift-check.sql
+++ b/scripts/drift-check.sql
@@ -1,0 +1,106 @@
+-- Supabase security drift detection.
+--
+-- Run this against a production Supabase project. Each row returned is a
+-- drift finding and MUST be investigated. The CI wrapper
+-- (scripts/drift-check.sh) exits non-zero when this query returns any row.
+--
+-- Covered invariants:
+--   1. Every table in public must have Row Level Security enabled.
+--   2. Every table in public must be declared in supabase/schemas/01_tables.sql
+--      (drift caught when tables are created via the SQL Editor or external
+--      scripts — e.g. business_card_leads, crm_notifications, "People_backup").
+--   3. The anon role must not hold any privilege on public relations
+--      (enforced runtime by migrations/20260408120000_enforce_rls_security.sql,
+--      re-checked here in case someone GRANTs it back manually).
+--   4. The anon role must not hold EXECUTE on any public function.
+--   5. The `attachments` storage bucket must be private
+--      (flipped by migrations/20260408140000_attachments_bucket_private.sql).
+--   6. Storage buckets never revert to public = true.
+--
+-- The declared-tables allowlist is hard-coded below so the drift check is
+-- fully self-contained and can be reviewed at a glance. Update it whenever
+-- a new table is added to supabase/schemas/01_tables.sql.
+
+with declared_tables(name) as (
+  values
+    ('companies'),
+    ('contacts'),
+    ('contact_notes'),
+    ('deals'),
+    ('deal_notes'),
+    ('sales'),
+    ('tags'),
+    ('tasks'),
+    ('configuration'),
+    ('favicons_excluded_domains'),
+    ('google_oauth_tokens'),
+    ('connector_preferences')
+)
+-- 1. tables without RLS
+select
+  'rls_disabled' as finding,
+  format('%I.%I', schemaname, tablename) as object,
+  'ALTER TABLE ... ENABLE ROW LEVEL SECURITY' as remediation
+from pg_tables
+where schemaname = 'public'
+  and rowsecurity = false
+
+union all
+
+-- 2. tables not declared in 01_tables.sql
+select
+  'undeclared_table',
+  format('public.%I', c.relname),
+  'Add the table to supabase/schemas/01_tables.sql or drop it'
+from pg_class c
+join pg_namespace n on n.oid = c.relnamespace
+where n.nspname = 'public'
+  and c.relkind = 'r'
+  and c.relname not in (select name from declared_tables)
+
+union all
+
+-- 3. anon grants on public tables
+select distinct
+  'anon_table_grant',
+  format('public.%I (%s)', g.table_name, g.privilege_type),
+  'REVOKE ... ON TABLE ... FROM anon'
+from information_schema.role_table_grants g
+where g.table_schema = 'public'
+  and g.grantee = 'anon'
+
+union all
+
+-- 4. anon EXECUTE on public functions
+select
+  'anon_function_grant',
+  format('public.%I(%s)', p.proname, pg_get_function_identity_arguments(p.oid)),
+  'REVOKE EXECUTE ON FUNCTION ... FROM anon'
+from pg_proc p
+join pg_namespace n on n.oid = p.pronamespace
+where n.nspname = 'public'
+  and has_function_privilege('anon', p.oid, 'EXECUTE')
+
+union all
+
+-- 5. attachments bucket must be private
+select
+  'attachments_bucket_public',
+  id,
+  'UPDATE storage.buckets SET public = false WHERE id = ''attachments'''
+from storage.buckets
+where id = 'attachments'
+  and public = true
+
+union all
+
+-- 6. any other public bucket
+select
+  'public_storage_bucket',
+  id,
+  'Review whether this bucket really needs unauthenticated reads'
+from storage.buckets
+where public = true
+  and id <> 'attachments'
+
+order by finding, object;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "v1.9.28";
+export const APP_VERSION = "v1.9.29";

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "v1.9.27";
+export const APP_VERSION = "v1.9.28";


### PR DESCRIPTION
## Pourquoi

Les PRs #14, #15 et #16 ont fixé l'état actuel mais rien n'empêche quelqu'un de régresser les invariants via le SQL Editor de Supabase — c'est exactement comme ça que `business_card_leads`, `crm_notifications` et `"People_backup"` sont apparues. Il faut un **garde-fou automatique**.

## Ce que fait ce PR

### `scripts/drift-check.sql`
Une seule requête read-only qui union six invariants en un result set. Chaque ligne = un finding ; zéro ligne = clean.

| # | Invariant | Finding |
|---|---|---|
| 1 | RLS activée sur toute table `public` | `rls_disabled` |
| 2 | Toute table `public` est déclarée dans `01_tables.sql` | `undeclared_table` |
| 3 | Le rôle `anon` n'a aucun privilège sur les tables `public` | `anon_table_grant` |
| 4 | Le rôle `anon` n'a pas `EXECUTE` sur les fonctions `public` | `anon_function_grant` |
| 5 | Le bucket `attachments` reste privé | `attachments_bucket_public` |
| 6 | Aucun autre bucket storage n'est `public = true` | `public_storage_bucket` |

L'allowlist des 12 tables déclarées est hardcodée dans la CTE pour que le fichier soit auto-suffisant et reviewable. À mettre à jour quand on ajoute une table à `01_tables.sql`.

### `scripts/drift-check.sh`
Wrapper bash qui exécute le SQL via `psql` et :
- exit `0` si clean → `[label] OK: no security drift detected`
- exit `1` si drift détecté → report aligné sur 3 colonnes `FINDING / OBJECT / REMEDIATION`
- exit `2` sur erreur de config (secret absent, psql absent, fichier SQL absent)

Lit `SUPABASE_DB_URL` en env. `SUPABASE_LABEL` optionnel pour distinguer plusieurs projets dans les logs.

### `.github/workflows/security-drift.yml`
GitHub Actions :
- **Triggers** : PRs touchant `supabase/**` ou les scripts, cron daily 06:00 UTC, `workflow_dispatch`
- Installe `postgresql-client`
- Vérifie que le secret existe (erreur explicite sinon)
- Appelle `./scripts/drift-check.sh`

## Setup requis côté repo

Un seul secret à ajouter : **`SUPABASE_DB_URL`**.

Où le trouver : Supabase Studio → Project Settings → Database → **Session pooler** (IPv4-compatible pour GitHub Actions). Format :
```
postgresql://postgres.<project-ref>:<db-password>@aws-0-<region>.pooler.supabase.com:5432/postgres
```

Si tu as plusieurs projets à surveiller (`kmtoziejeblhdggjghrx` et `vrnjdsxdkqmdfdcydlas`), on peut étendre le workflow en matrix quand tu veux. Pour l'instant on commence avec un seul.

## Tests end-to-end

Testé localement contre un postgres 16 en installant `postgresql-client` et en simulant les deux états :

**État clean :**
```
[local-test] OK: no security drift detected.
exit=0
```

**État sale** (table drift + 2 buckets publics + RLS manquante) :
```
[local-test] ✗ security drift detected:

FINDING                    OBJECT                       REMEDIATION
-------                    ------                       -----------
attachments_bucket_public  attachments                  UPDATE storage.buckets SET public = false WHERE id = 'attachments'
public_storage_bucket      avatars                      Review whether this bucket really needs unauthenticated reads
rls_disabled               public.business_card_leads   ALTER TABLE ... ENABLE ROW LEVEL SECURITY
undeclared_table           public.business_card_leads   Add the table to supabase/schemas/01_tables.sql or drop it
exit=1
```

Le script détecte bien les 4 familles de finding et sort 1.

## Test plan

- [x] `shellcheck scripts/drift-check.sh` clean
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` YAML valide
- [x] Smoke e2e contre postgres local (clean + dirty states)
- [ ] Après merge : ajouter le secret `SUPABASE_DB_URL` puis déclencher manuellement le workflow via `workflow_dispatch` pour valider le premier run
- [ ] Vérifier que le run post-merge retourne OK (après le hardening de #14/#15/#16)

## Suite possible

- Étendre en matrix pour couvrir les deux projets Supabase simultanément
- Ajouter une alerte Slack / issue GitHub en cas de finding pendant le run cron (sinon un drift passera inaperçu tant que personne ne regarde les runs)