### PR TITLE
fix(deals): create deals_summary view (collision de timestamp migration)

### DIFF
--- a/supabase/migrations/20260409120000_deals_summary_view.sql
+++ b/supabase/migrations/20260409120000_deals_summary_view.sql
@@ -1,0 +1,32 @@
+-- Create the deals_summary view that the frontend reads from.
+--
+-- History: a previous attempt landed in migration
+-- 20260408120000_deals_summary_view.sql, but that file shares its timestamp
+-- with 20260408120000_enforce_rls_security.sql. Supabase tracks migrations by
+-- their leading timestamp, so only one of the two ever made it into
+-- supabase_migrations.schema_migrations on the remote — the view was never
+-- created, which surfaced as PostgREST's "Could not find the table
+-- 'public.deals_summary' in the schema cache" error on /deals.
+--
+-- This migration uses CREATE OR REPLACE VIEW so it is safe to run whether or
+-- not the old file happened to execute. It also aligns the view's GRANTs with
+-- 20260408120000_enforce_rls_security.sql: anon must never receive privileges
+-- on public relations, only authenticated and service_role do.
+
+create or replace view public.deals_summary
+  with (security_invoker = on)
+  as
+select
+    d.*,
+    coalesce(string_agg((c.first_name || ' ' || c.last_name), ' '), '') as contact_names,
+    lower(immutable_unaccent(coalesce(string_agg((c.first_name || ' ' || c.last_name), ' '), ''))) as contact_names_search
+from public.deals d
+    left join public.contacts c on c.id = any(d.contact_ids)
+group by d.id;
+
+-- Make sure anon never has access, even if the old duplicate-timestamp
+-- migration previously granted it.
+revoke all on table public.deals_summary from anon;
+
+grant all on table public.deals_summary to authenticated;
+grant all on table public.deals_summary to service_role;

--- a/supabase/schemas/06_grants.sql
+++ b/supabase/schemas/06_grants.sql
@@ -101,6 +101,9 @@ grant all on table public.companies_summary to service_role;
 grant all on table public.contacts_summary to authenticated;
 grant all on table public.contacts_summary to service_role;
 
+grant all on table public.deals_summary to authenticated;
+grant all on table public.deals_summary to service_role;
+
 grant all on table public.init_state to authenticated;
 grant all on table public.init_state to service_role;
 


### PR DESCRIPTION
## Problème

La page `/deals` affichait :

> Could not find the table 'public.deals_summary' in the schema cache

La vue `deals_summary` n'existait tout simplement pas sur le remote Supabase.

## Cause racine

Deux migrations partagent le même timestamp `20260408120000` :

- `supabase/migrations/20260408120000_deals_summary_view.sql`
- `supabase/migrations/20260408120000_enforce_rls_security.sql`

Supabase indexe les migrations dans `supabase_migrations.schema_migrations` par leur timestamp, donc une seule des deux a été enregistrée — la vue n'a jamais été créée. En bonus, l'ancien fichier accordait `GRANT SELECT ... TO anon`, ce qui contredit le verrouillage `anon` fait par la migration RLS.

## Fix

- Nouvelle migration `supabase/migrations/20260409120000_deals_summary_view.sql` avec un timestamp unique, `CREATE OR REPLACE VIEW` (idempotente quel que soit l'état réel du remote), et `GRANT` limité à `authenticated` + `service_role` (avec `REVOKE ... FROM anon` explicite pour nettoyer l'ancien grant fautif si jamais il a été appliqué).
- `supabase/schemas/06_grants.sql` : déclaration des mêmes grants pour garder le schéma déclaratif cohérent.
- `supabase/schemas/03_views.sql` contenait déjà la bonne définition — pas de changement nécessaire là.

## Déploiement

Le workflow `.github/workflows/deploy.yml` exécute `npx supabase db push` automatiquement sur push vers `main` (étape "📡 Push supabase migrations"). Merger cette PR applique donc la migration sur le remote sans intervention manuelle.

## Test plan

- [ ] Merge la PR
- [ ] Vérifier que le job `deploy-supabase` passe sur l'Actions tab
- [ ] Recharger `/deals` — la page Opportunités doit lister les deals sans l'erreur PostgREST
- [ ] Vérifier dans le Supabase SQL editor : `select count(*) from public.deals_summary;` retourne une ligne

https://claude.ai/code/session_011oFKDocJn6jcbVCEEac9wb