### PR TITLE
fix(ci): silence TS6 baseUrl deprecation to unblock deploy

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -6,6 +6,7 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "ignoreDeprecations": "6.0",
 
     /* Bundler mode */
     "esModuleInterop": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     { "path": "./tsconfig.node.json" }
   ],
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "esModuleInterop": true,
     // Shadcn
     "baseUrl": ".",


### PR DESCRIPTION
TypeScript 6.0.2 traite `baseUrl` comme erreur fatale (TS5101). Chaque Deploy depuis la montée de version TS échouait à `npm run build` (~51s), empêchant `npx supabase db push` de s'exécuter — aucune migration n'a atteint le remote, y compris `deals_summary_view` (#19, #20).

Ajoute `"ignoreDeprecations": "6.0"` à `tsconfig.json` et `tsconfig.app.json` pour restaurer le build. Une fois ce PR mergé, Deploy 74 devrait passer et appliquer toutes les migrations en attente (dont `deals_summary`).