### PR TITLE
fix(ci): actually remove ignoreDeprecations from tsconfig

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -6,7 +6,6 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
-    "ignoreDeprecations": "6.0",
 
     /* Bundler mode */
     "esModuleInterop": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     { "path": "./tsconfig.node.json" }
   ],
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
     "esModuleInterop": true,
     // Shadcn
     "baseUrl": ".",


### PR DESCRIPTION
La PR #22 devait supprimer `ignoreDeprecations: "6.0"` mais le squash merge a produit un diff vide (les deux commits se sont annulés). Ce commit effectue la suppression réelle. Vérifié : `grep ignoreDeprecations tsconfig*.json` → 0 résultat.