### PR TITLE
feat(deals): show card count next to kanban column title (v1.9.38)

### DIFF
--- a/src/components/atomic-crm/deals/DealColumn.tsx
+++ b/src/components/atomic-crm/deals/DealColumn.tsx
@@ -19,7 +19,7 @@ export const DealColumn = ({
     <div className="flex-1 pb-8">
       <div className="flex flex-col items-center">
         <h3 className="text-base font-medium">
-          {findDealLabel(dealStages, stage)}
+          {findDealLabel(dealStages, stage)} ({deals.length})
         </h3>
         <p className="text-sm text-muted-foreground">
           {totalAmount.toLocaleString("en-US", {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "v1.9.37";
+export const APP_VERSION = "v1.9.38";


### PR DESCRIPTION
Affiche le nombre de cartes entre parenthèses à côté du titre de chaque colonne du Kanban des opportunités, ex: `Gagné (10)`.

v1.9.38