### PR TITLE
feat(assist): AI chat flottant pour feedback et bugs

### DIFF
--- a/src/components/atomic-crm/assist/NoshoAssistChat.tsx
+++ b/src/components/atomic-crm/assist/NoshoAssistChat.tsx
@@ -1,0 +1,252 @@
+import { useEffect, useRef, useState } from "react";
+import { Loader2, Send, Sparkles } from "lucide-react";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useAssist } from "./assistStore";
+import { useAssistChat } from "./useAssistChat";
+
+const TYPE_LABEL: Record<"bug" | "feature" | "question", string> = {
+  bug: "Bug",
+  feature: "Idée de fonctionnalité",
+  question: "Question",
+};
+
+export function NoshoAssistChat() {
+  const { isOpen, initialMessage, close } = useAssist();
+  const {
+    messages,
+    draft,
+    isSending,
+    isSubmitting,
+    error,
+    sendMessage,
+    submitDraft,
+    reset,
+  } = useAssistChat();
+
+  const [input, setInput] = useState("");
+  const [submitted, setSubmitted] = useState<{ url?: string } | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Reset state on open, optionally seeding the textarea with a message.
+  useEffect(() => {
+    if (!isOpen) return;
+    reset();
+    setSubmitted(null);
+    setInput(initialMessage ?? "");
+    // Focus shortly after the sheet animation starts.
+    const t = setTimeout(() => textareaRef.current?.focus(), 200);
+    return () => clearTimeout(t);
+  }, [isOpen, initialMessage, reset]);
+
+  // Auto-scroll on new messages.
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [messages, isSending]);
+
+  const handleSend = async () => {
+    const text = input.trim();
+    if (!text || isSending) return;
+    setInput("");
+    await sendMessage(text);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  const handleSubmit = async () => {
+    const result = await submitDraft();
+    if (result?.ok) {
+      setSubmitted({ url: result.issueUrl });
+    }
+  };
+
+  return (
+    <Sheet
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) close();
+      }}
+    >
+      <SheetContent
+        side="right"
+        className="w-full sm:max-w-md flex flex-col p-0 gap-0"
+      >
+        <SheetHeader className="border-b">
+          <div className="flex items-center gap-3 pr-8">
+            <div className="flex items-center justify-center w-9 h-9 rounded-xl bg-gradient-to-br from-[var(--nosho-orange)] to-[var(--nosho-green)] shrink-0">
+              <Sparkles className="w-4.5 h-4.5 text-white" />
+            </div>
+            <div className="flex flex-col min-w-0">
+              <SheetTitle>Nosho AI Assist</SheetTitle>
+              <SheetDescription>
+                Décrivez un bug, une idée, ou posez une question.
+              </SheetDescription>
+            </div>
+          </div>
+        </SheetHeader>
+
+        <div
+          ref={scrollRef}
+          className="flex-1 overflow-y-auto px-4 py-4 space-y-3"
+        >
+          {messages.length === 0 && (
+            <div className="text-sm text-muted-foreground text-center py-8">
+              Comment puis-je vous aider ?
+              <br />
+              <span className="text-xs">
+                Tapez votre message ci-dessous, je vous poserai quelques
+                questions et je transmettrai votre demande à l'équipe.
+              </span>
+            </div>
+          )}
+
+          {messages.map((msg, i) => (
+            <MessageBubble key={i} role={msg.role} content={msg.content} />
+          ))}
+
+          {isSending && (
+            <div className="flex items-center gap-2 text-xs text-muted-foreground px-1">
+              <Loader2 className="w-3 h-3 animate-spin" />
+              <span>Nosho réfléchit…</span>
+            </div>
+          )}
+
+          {error && (
+            <div className="text-xs text-destructive bg-destructive/10 rounded-md px-3 py-2">
+              {error}
+            </div>
+          )}
+
+          {draft && !submitted && (
+            <div className="rounded-lg border border-[var(--nosho-green)]/40 bg-[var(--nosho-green)]/5 p-3 space-y-2">
+              <div className="flex items-center gap-2">
+                <span className="text-xs font-semibold uppercase tracking-wide text-[var(--nosho-green-dark)]">
+                  {TYPE_LABEL[draft.type]}
+                </span>
+              </div>
+              <h4 className="text-sm font-semibold text-foreground">
+                {draft.title}
+              </h4>
+              <p className="text-xs text-muted-foreground whitespace-pre-wrap">
+                {draft.summary}
+              </p>
+              <Button
+                type="button"
+                size="sm"
+                className="w-full bg-[var(--nosho-green)] hover:bg-[var(--nosho-green-dark)] text-white"
+                onClick={handleSubmit}
+                disabled={isSubmitting}
+              >
+                {isSubmitting ? (
+                  <>
+                    <Loader2 className="w-3 h-3 animate-spin" />
+                    Envoi…
+                  </>
+                ) : (
+                  <>Envoyer la demande à l'équipe</>
+                )}
+              </Button>
+            </div>
+          )}
+
+          {submitted && (
+            <div className="rounded-lg border border-[var(--nosho-green)]/40 bg-[var(--nosho-green)]/10 p-4 text-sm text-foreground">
+              <p className="font-semibold mb-1">Merci !</p>
+              <p className="text-xs text-muted-foreground">
+                Votre demande a bien été envoyée à l'équipe Nosho. Vous serez
+                tenu au courant sur Slack.
+              </p>
+              {submitted.url && (
+                <a
+                  href={submitted.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-xs text-[var(--nosho-green-dark)] underline mt-2 inline-block"
+                >
+                  Voir le ticket
+                </a>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className="border-t p-3">
+          <div className="flex items-end gap-2">
+            <Textarea
+              ref={textareaRef}
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Comment puis-je vous aider ?"
+              rows={2}
+              className="resize-none min-h-[44px] max-h-32"
+              disabled={isSending || !!submitted}
+            />
+            <Button
+              type="button"
+              size="icon"
+              onClick={handleSend}
+              disabled={!input.trim() || isSending || !!submitted}
+              className="shrink-0"
+            >
+              <Send className="w-4 h-4" />
+            </Button>
+          </div>
+          <p className="text-[10px] text-muted-foreground mt-1.5 px-1">
+            Entrée pour envoyer · Maj+Entrée pour aller à la ligne
+          </p>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function MessageBubble({
+  role,
+  content,
+}: {
+  role: "user" | "assistant";
+  content: string;
+}) {
+  // Strip the JSON fence from the assistant display - the parsed draft is
+  // already shown as a structured card below the message stream.
+  const display =
+    role === "assistant"
+      ? content.replace(/```json[\s\S]*?```/gi, "").trim()
+      : content;
+
+  if (role === "assistant" && !display) return null;
+
+  return (
+    <div
+      className={cn("flex", role === "user" ? "justify-end" : "justify-start")}
+    >
+      <div
+        className={cn(
+          "max-w-[85%] rounded-2xl px-3 py-2 text-sm whitespace-pre-wrap",
+          role === "user"
+            ? "bg-primary text-primary-foreground rounded-br-sm"
+            : "bg-muted text-foreground rounded-bl-sm",
+        )}
+      >
+        {display}
+      </div>
+    </div>
+  );
+}

--- a/src/components/atomic-crm/assist/NoshoAssistFAB.tsx
+++ b/src/components/atomic-crm/assist/NoshoAssistFAB.tsx
@@ -1,0 +1,29 @@
+import { Sparkles } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useAssist } from "./assistStore";
+
+export function NoshoAssistFAB() {
+  const { open, isOpen } = useAssist();
+
+  if (isOpen) return null;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          aria-label="Aide & feedback"
+          onClick={() => open()}
+          className="fixed bottom-6 right-6 z-[60] w-12 h-12 rounded-full bg-gradient-to-br from-[var(--nosho-orange)] to-[var(--nosho-green)] shadow-lg shadow-black/20 hover:shadow-xl hover:scale-105 active:scale-95 transition-all flex items-center justify-center cursor-pointer ring-2 ring-white/20"
+        >
+          <Sparkles className="w-5 h-5 text-white" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="left">Aide & feedback</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/components/atomic-crm/assist/assistStore.tsx
+++ b/src/components/atomic-crm/assist/assistStore.tsx
@@ -1,0 +1,51 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+type AssistContextValue = {
+  isOpen: boolean;
+  initialMessage: string | null;
+  open: (initialMessage?: string) => void;
+  close: () => void;
+};
+
+const AssistContext = createContext<AssistContextValue | null>(null);
+
+export function AssistProvider({ children }: { children: ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [initialMessage, setInitialMessage] = useState<string | null>(null);
+
+  const open = useCallback((message?: string) => {
+    setInitialMessage(message ?? null);
+    setIsOpen(true);
+  }, []);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    // Clear the seed message after the close animation so re-opening from the
+    // FAB starts fresh.
+    setTimeout(() => setInitialMessage(null), 300);
+  }, []);
+
+  const value = useMemo(
+    () => ({ isOpen, initialMessage, open, close }),
+    [isOpen, initialMessage, open, close],
+  );
+
+  return (
+    <AssistContext.Provider value={value}>{children}</AssistContext.Provider>
+  );
+}
+
+export function useAssist() {
+  const ctx = useContext(AssistContext);
+  if (!ctx) {
+    throw new Error("useAssist must be used inside <AssistProvider>");
+  }
+  return ctx;
+}

--- a/src/components/atomic-crm/assist/useAssistChat.ts
+++ b/src/components/atomic-crm/assist/useAssistChat.ts
@@ -1,0 +1,156 @@
+import { useCallback, useState } from "react";
+import { getSupabaseClient } from "../providers/supabase/supabase";
+
+export type ChatMessage = {
+  role: "user" | "assistant";
+  content: string;
+};
+
+export type AssistDraft = {
+  type: "bug" | "feature" | "question";
+  title: string;
+  summary: string;
+  ready: true;
+};
+
+type AssistChatResponse = {
+  reply: string;
+  draft?: AssistDraft;
+};
+
+type SubmitResponse = {
+  ok: boolean;
+  issueUrl?: string;
+};
+
+/**
+ * Try to extract a JSON draft from the assistant's reply.
+ * Claude is instructed to wrap its final answer in a ```json ... ``` block.
+ */
+function extractDraft(text: string): AssistDraft | null {
+  const fenced = text.match(/```json\s*([\s\S]*?)```/i);
+  const candidate = fenced ? fenced[1] : null;
+  if (!candidate) return null;
+  try {
+    const parsed = JSON.parse(candidate);
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      parsed.ready === true &&
+      typeof parsed.title === "string" &&
+      typeof parsed.summary === "string" &&
+      ["bug", "feature", "question"].includes(parsed.type)
+    ) {
+      return parsed as AssistDraft;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+export function useAssistChat() {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [draft, setDraft] = useState<AssistDraft | null>(null);
+  const [isSending, setIsSending] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = useCallback(() => {
+    setMessages([]);
+    setDraft(null);
+    setError(null);
+    setIsSending(false);
+    setIsSubmitting(false);
+  }, []);
+
+  const sendMessage = useCallback(
+    async (text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed || isSending) return;
+
+      setError(null);
+      const userMessage: ChatMessage = { role: "user", content: trimmed };
+      const nextMessages = [...messages, userMessage];
+      setMessages(nextMessages);
+      setIsSending(true);
+
+      try {
+        const { data, error: invokeError } =
+          await getSupabaseClient().functions.invoke<AssistChatResponse>(
+            "assist-chat",
+            {
+              body: {
+                messages: nextMessages,
+                context: {
+                  currentRoute:
+                    typeof window !== "undefined"
+                      ? window.location.pathname + window.location.hash
+                      : "",
+                },
+              },
+            },
+          );
+
+        if (invokeError) throw invokeError;
+        if (!data?.reply) throw new Error("Réponse vide de l'assistant");
+
+        const assistantMessage: ChatMessage = {
+          role: "assistant",
+          content: data.reply,
+        };
+        setMessages((prev) => [...prev, assistantMessage]);
+
+        const extracted = data.draft ?? extractDraft(data.reply);
+        if (extracted) setDraft(extracted);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setIsSending(false);
+      }
+    },
+    [messages, isSending],
+  );
+
+  const submitDraft = useCallback(async (): Promise<SubmitResponse | null> => {
+    if (!draft || isSubmitting) return null;
+    setError(null);
+    setIsSubmitting(true);
+    try {
+      const { data, error: invokeError } =
+        await getSupabaseClient().functions.invoke<SubmitResponse>(
+          "assist-submit",
+          {
+            body: {
+              draft,
+              currentRoute:
+                typeof window !== "undefined"
+                  ? window.location.pathname + window.location.hash
+                  : "",
+              userAgent:
+                typeof navigator !== "undefined" ? navigator.userAgent : "",
+              transcript: messages,
+            },
+          },
+        );
+      if (invokeError) throw invokeError;
+      return data ?? null;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      return null;
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [draft, messages, isSubmitting]);
+
+  return {
+    messages,
+    draft,
+    isSending,
+    isSubmitting,
+    error,
+    sendMessage,
+    submitDraft,
+    reset,
+  };
+}

--- a/src/components/atomic-crm/dashboard/NoshoAIAssist.tsx
+++ b/src/components/atomic-crm/dashboard/NoshoAIAssist.tsx
@@ -1,7 +1,9 @@
 import { Sparkles } from "lucide-react";
 import { Card } from "@/components/ui/card";
+import { useAssist } from "../assist/assistStore";
 
 export function NoshoAIAssist() {
+  const { open } = useAssist();
   return (
     <Card className="p-4 shadow-sm border-border/50 bg-gradient-to-br from-[var(--nosho-orange)]/5 to-[var(--nosho-green)]/5">
       <div className="flex items-start gap-3">
@@ -18,6 +20,11 @@ export function NoshoAIAssist() {
           </p>
           <button
             type="button"
+            onClick={() =>
+              open(
+                "Bonjour, peux-tu m'aider à analyser mes contacts récents et me suggérer des actions ?",
+              )
+            }
             className="mt-1 self-start text-xs font-medium px-3 py-1.5 rounded-lg bg-[var(--nosho-green)]/15 text-[var(--nosho-green-dark)] hover:bg-[var(--nosho-green)]/25 transition-colors cursor-pointer"
           >
             Analyser mes contacts

--- a/src/components/atomic-crm/layout/Layout.tsx
+++ b/src/components/atomic-crm/layout/Layout.tsx
@@ -5,6 +5,9 @@ import { Notification } from "@/components/admin/notification";
 import { Error } from "@/components/admin/error";
 import { Skeleton } from "@/components/ui/skeleton";
 
+import { AssistProvider } from "../assist/assistStore";
+import { NoshoAssistChat } from "../assist/NoshoAssistChat";
+import { NoshoAssistFAB } from "../assist/NoshoAssistFAB";
 import { useConfigurationLoader } from "../root/useConfigurationLoader";
 import Header from "./Header";
 
@@ -20,7 +23,7 @@ const SentryErrorBoundary = Sentry.withErrorBoundary(
 export const Layout = ({ children }: { children: ReactNode }) => {
   useConfigurationLoader();
   return (
-    <>
+    <AssistProvider>
       <Header />
       <main className="w-full pt-4 px-[50px]" id="main-content">
         <SentryErrorBoundary>
@@ -33,7 +36,9 @@ export const Layout = ({ children }: { children: ReactNode }) => {
           </ErrorBoundary>
         </SentryErrorBoundary>
       </main>
+      <NoshoAssistFAB />
+      <NoshoAssistChat />
       <Notification />
-    </>
+    </AssistProvider>
   );
 };

--- a/supabase/functions/assist-chat/index.ts
+++ b/supabase/functions/assist-chat/index.ts
@@ -1,0 +1,154 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { corsHeaders, OptionsMiddleware } from "../_shared/cors.ts";
+import { AuthMiddleware } from "../_shared/authentication.ts";
+
+const ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages";
+const MODEL = "claude-sonnet-4-6";
+const MAX_TOKENS = 1024;
+
+const SYSTEM_PROMPT = `Tu es Nosho AI Assist, un assistant intégré au CRM Nosho.
+Tu aides Thomas (CEO), Benjamin (responsable des ventes), Denis et Julie à formuler
+des demandes d'amélioration ou des bugs sans qu'ils aient à ouvrir GitHub eux-mêmes.
+
+Ton style : chaleureux, concis, en français. Tutoiement.
+
+Étape 1 — Comprendre. Pose 1 à 3 questions courtes maximum (idéalement 1 ou 2)
+pour clarifier :
+  - Est-ce un bug, une nouvelle idée, ou une question ?
+  - Sur quelle vue / quel écran (contacts, opportunités, dashboard…) ?
+  - Quel est l'impact concret pour le travail de l'utilisateur ?
+
+Ne pose JAMAIS plus de 3 questions au total. Si l'utilisateur a déjà donné assez
+d'info dès le premier message, passe directement à l'étape 2.
+
+Étape 2 — Récapituler. Quand tu as compris, écris une ou deux phrases d'accusé
+de réception en français, PUIS ajoute STRICTEMENT en fin de message un bloc :
+
+\`\`\`json
+{
+  "type": "bug" | "feature" | "question",
+  "title": "<titre court, moins de 70 caractères>",
+  "summary": "<3 à 5 puces markdown décrivant la demande, le contexte et l'impact>",
+  "ready": true
+}
+\`\`\`
+
+Le champ "ready": true est OBLIGATOIRE pour déclencher l'envoi côté UI.
+N'invente jamais de fonctionnalités déjà existantes. En cas de doute, demande.`;
+
+type ChatMessage = {
+  role: "user" | "assistant";
+  content: string;
+};
+
+type RequestBody = {
+  messages?: ChatMessage[];
+  context?: {
+    currentRoute?: string;
+  };
+};
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+async function handler(req: Request): Promise<Response> {
+  const apiKey = Deno.env.get("ANTHROPIC_API_KEY");
+  if (!apiKey) {
+    console.error("[assist-chat] ANTHROPIC_API_KEY secret is not set");
+    return jsonResponse(500, { error: "ANTHROPIC_API_KEY not configured" });
+  }
+
+  let body: RequestBody;
+  try {
+    body = await req.json();
+  } catch (e) {
+    console.error("[assist-chat] Invalid JSON body:", e);
+    return jsonResponse(400, { error: "Invalid JSON body" });
+  }
+
+  const messages = Array.isArray(body.messages) ? body.messages : [];
+  if (messages.length === 0) {
+    return jsonResponse(400, { error: "messages array is required" });
+  }
+
+  // Sanitize messages — only keep role + content fields, cap content length.
+  const sanitized = messages
+    .filter(
+      (m) =>
+        m &&
+        (m.role === "user" || m.role === "assistant") &&
+        typeof m.content === "string",
+    )
+    .map((m) => ({
+      role: m.role,
+      content: m.content.slice(0, 4000),
+    }));
+
+  const contextLine = body.context?.currentRoute
+    ? `\n\n[Contexte UI: l'utilisateur est sur la route "${body.context.currentRoute}"]`
+    : "";
+
+  const anthropicBody = {
+    model: MODEL,
+    max_tokens: MAX_TOKENS,
+    system: [
+      {
+        type: "text",
+        text: SYSTEM_PROMPT + contextLine,
+        // Cache the system prompt — saves tokens on every follow-up turn.
+        cache_control: { type: "ephemeral" },
+      },
+    ],
+    messages: sanitized,
+  };
+
+  let res: Response;
+  try {
+    res = await fetch(ANTHROPIC_API_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify(anthropicBody),
+    });
+  } catch (e) {
+    console.error("[assist-chat] fetch failed:", e);
+    return jsonResponse(502, { error: "Failed to reach Anthropic API" });
+  }
+
+  if (!res.ok) {
+    const text = await res.text();
+    console.error(`[assist-chat] Anthropic ${res.status}: ${text}`);
+    return jsonResponse(res.status, {
+      error: `Anthropic error ${res.status}`,
+      detail: text,
+    });
+  }
+
+  const data = await res.json();
+  const reply: string =
+    Array.isArray(data?.content) && data.content[0]?.type === "text"
+      ? data.content[0].text
+      : "";
+
+  if (!reply) {
+    console.warn("[assist-chat] empty reply from Anthropic", data);
+    return jsonResponse(502, { error: "Empty reply from Anthropic" });
+  }
+
+  console.log(
+    `[assist-chat] turn ok — ${sanitized.length} msgs in, ${reply.length} chars out`,
+  );
+
+  return jsonResponse(200, { reply });
+}
+
+Deno.serve((req) =>
+  OptionsMiddleware(req, (req) => AuthMiddleware(req, handler)),
+);

--- a/supabase/functions/assist-submit/index.ts
+++ b/supabase/functions/assist-submit/index.ts
@@ -1,0 +1,160 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { type User } from "jsr:@supabase/supabase-js@2";
+import { corsHeaders, OptionsMiddleware } from "../_shared/cors.ts";
+import { AuthMiddleware, UserMiddleware } from "../_shared/authentication.ts";
+import { getUserSale } from "../_shared/getUserSale.ts";
+import { createErrorResponse } from "../_shared/utils.ts";
+
+type Draft = {
+  type: "bug" | "feature" | "question";
+  title: string;
+  summary: string;
+  ready: true;
+};
+
+type ChatMessage = {
+  role: "user" | "assistant";
+  content: string;
+};
+
+type RequestBody = {
+  draft?: Draft;
+  currentRoute?: string;
+  userAgent?: string;
+  transcript?: ChatMessage[];
+};
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+function isValidDraft(d: unknown): d is Draft {
+  if (!d || typeof d !== "object") return false;
+  const draft = d as Record<string, unknown>;
+  return (
+    (draft.type === "bug" ||
+      draft.type === "feature" ||
+      draft.type === "question") &&
+    typeof draft.title === "string" &&
+    draft.title.length > 0 &&
+    typeof draft.summary === "string" &&
+    draft.summary.length > 0 &&
+    draft.ready === true
+  );
+}
+
+async function handler(req: Request, user?: User): Promise<Response> {
+  if (req.method !== "POST") {
+    return createErrorResponse(405, "Method Not Allowed");
+  }
+
+  const webhookUrl = Deno.env.get("N8N_WEBHOOK_URL");
+  if (!webhookUrl) {
+    console.error("[assist-submit] N8N_WEBHOOK_URL secret is not set");
+    return jsonResponse(500, { error: "N8N_WEBHOOK_URL not configured" });
+  }
+
+  let body: RequestBody;
+  try {
+    body = await req.json();
+  } catch (e) {
+    console.error("[assist-submit] Invalid JSON body:", e);
+    return jsonResponse(400, { error: "Invalid JSON body" });
+  }
+
+  if (!isValidDraft(body.draft)) {
+    return jsonResponse(400, { error: "Invalid or missing draft" });
+  }
+
+  // Look up the sale row to get the human-readable author name.
+  let authorName = user?.email ?? "Unknown";
+  let authorEmail = user?.email ?? "";
+  if (user) {
+    try {
+      const sale = await getUserSale(user);
+      if (sale) {
+        const first = (sale as { first_name?: string }).first_name ?? "";
+        const last = (sale as { last_name?: string }).last_name ?? "";
+        const composed = `${first} ${last}`.trim();
+        if (composed) authorName = composed;
+        const saleEmail = (sale as { email?: string }).email;
+        if (saleEmail) authorEmail = saleEmail;
+      }
+    } catch (e) {
+      console.warn("[assist-submit] getUserSale failed:", e);
+    }
+  }
+
+  // Cap transcript size before forwarding so n8n doesn't choke on huge payloads.
+  const transcript = Array.isArray(body.transcript)
+    ? body.transcript.slice(-20).map((m) => ({
+        role: m.role,
+        content: typeof m.content === "string" ? m.content.slice(0, 4000) : "",
+      }))
+    : [];
+
+  const payload = {
+    source: "nosho-crm",
+    submittedAt: new Date().toISOString(),
+    author: {
+      name: authorName,
+      email: authorEmail,
+      userId: user?.id ?? null,
+    },
+    draft: body.draft,
+    context: {
+      currentRoute: body.currentRoute ?? "",
+      userAgent: body.userAgent ?? "",
+    },
+    transcript,
+  };
+
+  let webhookRes: Response;
+  try {
+    webhookRes = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+  } catch (e) {
+    console.error("[assist-submit] webhook fetch failed:", e);
+    return jsonResponse(502, { error: "Failed to reach n8n webhook" });
+  }
+
+  if (!webhookRes.ok) {
+    const text = await webhookRes.text();
+    console.error(`[assist-submit] n8n webhook ${webhookRes.status}: ${text}`);
+    return jsonResponse(502, {
+      error: `n8n webhook error ${webhookRes.status}`,
+      detail: text.slice(0, 500),
+    });
+  }
+
+  // n8n may return JSON with the created issue URL — bubble it up if present.
+  let issueUrl: string | undefined;
+  try {
+    const data = await webhookRes.json();
+    if (data && typeof data === "object" && typeof data.issueUrl === "string") {
+      issueUrl = data.issueUrl;
+    }
+  } catch {
+    // ignore non-JSON responses
+  }
+
+  console.log(
+    `[assist-submit] forwarded ${body.draft.type} from ${authorName}: "${body.draft.title}"`,
+  );
+
+  return jsonResponse(200, { ok: true, issueUrl });
+}
+
+Deno.serve((req) =>
+  OptionsMiddleware(req, (req) =>
+    AuthMiddleware(req, (req) =>
+      UserMiddleware(req, (req, user) => handler(req, user)),
+    ),
+  ),
+);


### PR DESCRIPTION
## Summary
- Ajout d'un assistant IA flottant (FAB + panel chat) accessible depuis toute l'app
- L'assistant pose des questions de clarification puis génère un draft structuré (bug / feature / question)
- Le draft validé est envoyé vers n8n qui crée un issue GitHub + notif Slack

## Composants
- **Frontend** : `NoshoAssistFAB`, `NoshoAssistChat`, `assistStore`, `useAssistChat`, carte dashboard
- **Backend** : Edge functions `assist-chat` (proxy Anthropic) et `assist-submit` (envoi n8n)

## Secrets requis (Doppler)
- `ANTHROPIC_API_KEY`
- `N8N_WEBHOOK_URL`

## Test plan
- [ ] Vérifier que le FAB s'affiche en bas à droite sur toutes les pages
- [ ] Ouvrir le chat, envoyer un message, vérifier la réponse de l'assistant
- [ ] Valider un draft et confirmer l'envoi vers n8n
- [ ] Tester sur mobile (sheet pleine largeur)

🤖 Generated with [Claude Code](https://claude.com/claude-code)