### PR TITLE
fix(google): production redirect URI pointed to localhost (v1.9.39)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,6 +114,9 @@ jobs:
             VITE_GOOGLE_WORKPLACE_DOMAIN: ${{secrets.VITE_GOOGLE_WORKPLACE_DOMAIN}}
             PAPPERS_API_KEY: ${{secrets.PAPPERS_API_KEY}}
             PHANTOMBUSTER_API_KEY: ${{secrets.PHANTOMBUSTER_API_KEY}}
+            GOOGLE_CLIENT_ID: ${{secrets.GOOGLE_CLIENT_ID}}
+            GOOGLE_CLIENT_SECRET: ${{secrets.GOOGLE_CLIENT_SECRET}}
+            GOOGLE_REDIRECT_URI: ${{secrets.GOOGLE_REDIRECT_URI}}
 
         steps:
             - name: 📥 Checkout repo
@@ -164,6 +167,13 @@ jobs:
               run: |
                   npx supabase secrets set PAPPERS_API_KEY=${{ env.PAPPERS_API_KEY }}
                   npx supabase secrets set PHANTOMBUSTER_API_KEY=${{ env.PHANTOMBUSTER_API_KEY }}
+
+            - if: ${{ env.IS_SUPABASE_CONFIGURED && env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET && env.GOOGLE_REDIRECT_URI }}
+              name: 📡 Push supabase Google OAuth secrets
+              run: |
+                  npx supabase secrets set GOOGLE_CLIENT_ID=${{ env.GOOGLE_CLIENT_ID }}
+                  npx supabase secrets set GOOGLE_CLIENT_SECRET=${{ env.GOOGLE_CLIENT_SECRET }}
+                  npx supabase secrets set GOOGLE_REDIRECT_URI=${{ env.GOOGLE_REDIRECT_URI }}
 
             - if: ${{ env.IS_SUPABASE_CONFIGURED }}
               name: 📡 Deploy supabase functions

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "v1.9.38";
+export const APP_VERSION = "v1.9.39";


### PR DESCRIPTION
## Summary
- **Root cause**: The Supabase secret `GOOGLE_REDIRECT_URI` was set to `http://localhost:5173/google-oauth-callback` instead of `https://crm.nosho.cc/google-oauth-callback`, causing Google OAuth to redirect users to localhost after consent
- **Fix**: Updated the secret on Supabase production to the correct production URL
- **Prevention**: Added Google OAuth secrets (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI`) to the CI/CD pipeline so they're automatically pushed on deploy, like Postmark and Pappers secrets already are

## ⚠️ Required: GitHub Secrets
For the CI/CD step to work on future deploys, these GitHub Actions secrets need to be set on the repo:
- `GOOGLE_CLIENT_ID`
- `GOOGLE_CLIENT_SECRET`
- `GOOGLE_REDIRECT_URI` = `https://crm.nosho.cc/google-oauth-callback`

## ⚠️ Required: Google Cloud Console
Verify that `https://crm.nosho.cc/google-oauth-callback` is listed as an authorized redirect URI in the Google Cloud Console OAuth credentials.

## Test plan
- [ ] Have the associate try connecting Google Workspace again — should redirect to `crm.nosho.cc` instead of `localhost`
- [ ] Verify the full OAuth flow completes (consent → callback → token exchange → connected status)

🤖 Generated with [Claude Code](https://claude.com/claude-code)