### PR TITLE
fix(auth): UserMiddleware edge functions 401 (v1.9.39)

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "v1.9.38";
+export const APP_VERSION = "v1.9.39";

--- a/supabase/functions/_shared/authentication.ts
+++ b/supabase/functions/_shared/authentication.ts
@@ -57,7 +57,9 @@ export const UserMiddleware = async (
     const authHeader = req.headers.get("Authorization")!;
     const localClient = createClient(
       Deno.env.get("SUPABASE_URL") ?? "",
-      Deno.env.get("SB_PUBLISHABLE_KEY") ?? "",
+      Deno.env.get("SUPABASE_ANON_KEY") ??
+        Deno.env.get("SB_PUBLISHABLE_KEY") ??
+        "",
       { global: { headers: { Authorization: authHeader } } },
     );
 


### PR DESCRIPTION
## Summary
- `UserMiddleware` utilisait uniquement `SB_PUBLISHABLE_KEY` (`sb_publishable_...`) qui n'est pas un JWT valide
- `auth.getUser()` échouait avec 401 sur `assist-chat` et `assist-submit`
- Alignement avec `AuthMiddleware` : fallback `SUPABASE_ANON_KEY` → `SB_PUBLISHABLE_KEY`

## Test plan
- [x] Edge function `assist-chat` testée en production — status 200
- [x] Flow complet testé : chat → draft → submit → issue GitHub créée
- [x] Edge functions déjà redéployées avec le fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)