### PR TITLE
fix(search): space-insensitive company autocomplete (v1.9.40)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -886,6 +886,22 @@
           "type": "registry:component"
         },
         {
+          "path": "src/components/atomic-crm/assist/useAssistChat.ts",
+          "type": "registry:component"
+        },
+        {
+          "path": "src/components/atomic-crm/assist/assistStore.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "src/components/atomic-crm/assist/NoshoAssistFAB.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "src/components/atomic-crm/assist/NoshoAssistChat.tsx",
+          "type": "registry:component"
+        },
+        {
           "path": "src/components/atomic-crm/activity/ActivityLogNote.tsx",
           "type": "registry:component"
         },

--- a/src/components/atomic-crm/providers/supabase/dataProvider.ts
+++ b/src/components/atomic-crm/providers/supabase/dataProvider.ts
@@ -634,6 +634,12 @@ const normalizeSearchQuery = (q: string): string =>
     .trim();
 
 /**
+ * Normalize for _search columns: also strip spaces so "SoClinic" matches "So Clinic".
+ */
+const normalizeForSearchColumn = (q: string): string =>
+  normalizeSearchQuery(q).replace(/\s+/g, "");
+
+/**
  * Columns that have a corresponding `_search` generated column in the DB
  * (lowercase + unaccented). Only these get the extra `_search@ilike` filter.
  */
@@ -660,9 +666,10 @@ const applyFullTextSearch = (columns: string[]) => (params: GetListParams) => {
   }
   const { q, ...filter } = params.filter;
   const normalizedQ = normalizeSearchQuery(q);
+  const spacelessQ = normalizeForSearchColumn(q);
 
   // Build OR conditions for a given query term
-  const buildConditions = (term: string) =>
+  const buildConditions = (term: string, searchColumnTerm: string) =>
     columns.reduce(
       (acc, column) => {
         if (column === "email") return { ...acc, [`email_fts@ilike`]: term };
@@ -671,9 +678,9 @@ const applyFullTextSearch = (columns: string[]) => (params: GetListParams) => {
           ...acc,
           [`${column}@ilike`]: term,
         };
-        // Only add _search filter for columns that have a generated _search column
+        // _search columns strip spaces, so match with spaceless term
         if (SEARCHABLE_COLUMNS.has(column)) {
-          conditions[`${column}_search@ilike`] = term;
+          conditions[`${column}_search@ilike`] = searchColumnTerm;
         }
         return conditions;
       },
@@ -683,8 +690,11 @@ const applyFullTextSearch = (columns: string[]) => (params: GetListParams) => {
   // If query has accents, search with both original and normalized terms
   const orConditions =
     normalizedQ !== q
-      ? { ...buildConditions(q), ...buildConditions(normalizedQ) }
-      : buildConditions(normalizedQ);
+      ? {
+          ...buildConditions(q, spacelessQ),
+          ...buildConditions(normalizedQ, spacelessQ),
+        }
+      : buildConditions(normalizedQ, spacelessQ);
 
   return {
     ...params,

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "v1.9.40";
+export const APP_VERSION = "v1.9.42";

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "v1.9.39";
+export const APP_VERSION = "v1.9.40";

--- a/supabase/migrations/20260416120000_search_strip_spaces.sql
+++ b/supabase/migrations/20260416120000_search_strip_spaces.sql
@@ -1,0 +1,86 @@
+-- Strip spaces from all _search generated columns so that
+-- "SoClinic" matches "So Clinic" and "JeanPierre" matches "Jean Pierre".
+--
+-- Formula: replace(lower(immutable_unaccent(coalesce(col, ''))), ' ', '')
+
+-- ── Drop views first (they depend on _search columns via table.*) ──────────
+DROP VIEW IF EXISTS contacts_summary;
+DROP VIEW IF EXISTS companies_summary;
+DROP VIEW IF EXISTS deals_summary;
+
+-- ── contacts ────────────────────────────────────────────────────────────────
+ALTER TABLE contacts
+  DROP COLUMN IF EXISTS first_name_search,
+  DROP COLUMN IF EXISTS last_name_search,
+  DROP COLUMN IF EXISTS title_search,
+  DROP COLUMN IF EXISTS background_search;
+
+ALTER TABLE contacts
+  ADD COLUMN first_name_search  text GENERATED ALWAYS AS (replace(lower(immutable_unaccent(coalesce(first_name,  ''))), ' ', '')) STORED,
+  ADD COLUMN last_name_search   text GENERATED ALWAYS AS (replace(lower(immutable_unaccent(coalesce(last_name,   ''))), ' ', '')) STORED,
+  ADD COLUMN title_search       text GENERATED ALWAYS AS (replace(lower(immutable_unaccent(coalesce(title,       ''))), ' ', '')) STORED,
+  ADD COLUMN background_search  text GENERATED ALWAYS AS (replace(lower(immutable_unaccent(coalesce(background,  ''))), ' ', '')) STORED;
+
+-- ── companies ───────────────────────────────────────────────────────────────
+ALTER TABLE companies
+  DROP COLUMN IF EXISTS name_search,
+  DROP COLUMN IF EXISTS city_search,
+  DROP COLUMN IF EXISTS state_abbr_search;
+
+ALTER TABLE companies
+  ADD COLUMN name_search       text GENERATED ALWAYS AS (replace(lower(immutable_unaccent(coalesce(name,        ''))), ' ', '')) STORED,
+  ADD COLUMN city_search       text GENERATED ALWAYS AS (replace(lower(immutable_unaccent(coalesce(city,        ''))), ' ', '')) STORED,
+  ADD COLUMN state_abbr_search text GENERATED ALWAYS AS (replace(lower(immutable_unaccent(coalesce(state_abbr,  ''))), ' ', '')) STORED;
+
+-- ── deals ───────────────────────────────────────────────────────────────────
+ALTER TABLE deals
+  DROP COLUMN IF EXISTS name_search,
+  DROP COLUMN IF EXISTS category_search,
+  DROP COLUMN IF EXISTS description_search;
+
+ALTER TABLE deals
+  ADD COLUMN name_search        text GENERATED ALWAYS AS (replace(lower(immutable_unaccent(coalesce(name,        ''))), ' ', '')) STORED,
+  ADD COLUMN category_search    text GENERATED ALWAYS AS (replace(lower(immutable_unaccent(coalesce(category,    ''))), ' ', '')) STORED,
+  ADD COLUMN description_search text GENERATED ALWAYS AS (replace(lower(immutable_unaccent(coalesce(description, ''))), ' ', '')) STORED;
+
+-- ── Recreate views ──────────────────────────────────────────────────────────
+
+CREATE VIEW companies_summary WITH (security_invoker = on) AS
+SELECT
+  c.*,
+  count(DISTINCT d.id)  AS nb_deals,
+  count(DISTINCT co.id) AS nb_contacts
+FROM companies c
+  LEFT JOIN deals    d  ON c.id = d.company_id
+  LEFT JOIN contacts co ON c.id = co.company_id
+GROUP BY c.id;
+
+CREATE VIEW contacts_summary WITH (security_invoker = on) AS
+SELECT
+  co.*,
+  c.name                                                                    AS company_name,
+  replace(lower(immutable_unaccent(coalesce(c.name, ''))), ' ', '')         AS company_name_search,
+  jsonb_path_query_array(co.email_jsonb, '$[*].email')::text                AS email_fts,
+  jsonb_path_query_array(co.phone_jsonb, '$[*].number')::text               AS phone_fts,
+  count(DISTINCT t.id) FILTER (WHERE t.done_date IS NULL)                   AS nb_tasks
+FROM contacts co
+  LEFT JOIN tasks t     ON co.id = t.contact_id
+  LEFT JOIN companies c ON co.company_id = c.id
+GROUP BY co.id, c.name;
+
+CREATE VIEW deals_summary WITH (security_invoker = on) AS
+SELECT
+  d.*,
+  comp.name                                                                                                    AS company_name,
+  replace(lower(immutable_unaccent(coalesce(comp.name, ''))), ' ', '')                                         AS company_name_search,
+  coalesce(string_agg((c.first_name || ' ' || c.last_name), ' '), '')                                         AS contact_names,
+  replace(lower(immutable_unaccent(coalesce(string_agg((c.first_name || ' ' || c.last_name), ' '), ''))), ' ', '') AS contact_names_search
+FROM deals d
+  LEFT JOIN contacts  c    ON c.id = ANY(d.contact_ids)
+  LEFT JOIN companies comp ON comp.id = d.company_id
+GROUP BY d.id, comp.name;
+
+-- Re-apply grants lost when views were dropped and recreated
+GRANT SELECT ON companies_summary TO authenticated, anon;
+GRANT SELECT ON contacts_summary  TO authenticated, anon;
+GRANT SELECT ON deals_summary     TO authenticated, anon;

--- a/supabase/schemas/03_views.sql
+++ b/supabase/schemas/03_views.sql
@@ -73,25 +73,7 @@ from public.deal_notes dn
 
 create or replace view public.companies_summary with (security_invoker = on) as
 select
-    c.id,
-    c.created_at,
-    c.name,
-    c.sector,
-    c.size,
-    c.linkedin_url,
-    c.website,
-    c.phone_number,
-    c.address,
-    c.zipcode,
-    c.city,
-    c.state_abbr,
-    c.sales_id,
-    c.context_links,
-    c.country,
-    c.description,
-    c.revenue,
-    c.tax_identifier,
-    c.logo,
+    c.*,
     count(distinct d.id) as nb_deals,
     count(distinct co.id) as nb_contacts
 from public.companies c
@@ -102,11 +84,11 @@ group by c.id;
 create or replace view public.contacts_summary with (security_invoker = on) as
 select
     co.*,
-    c.name                                                        as company_name,
-    lower(immutable_unaccent(coalesce(c.name, '')))               as company_name_search,
-    jsonb_path_query_array(co.email_jsonb, '$[*].email')::text    as email_fts,
-    jsonb_path_query_array(co.phone_jsonb, '$[*].number')::text   as phone_fts,
-    count(distinct t.id) filter (where t.done_date is null)       as nb_tasks
+    c.name                                                                    as company_name,
+    replace(lower(immutable_unaccent(coalesce(c.name, ''))), ' ', '')         as company_name_search,
+    jsonb_path_query_array(co.email_jsonb, '$[*].email')::text                as email_fts,
+    jsonb_path_query_array(co.phone_jsonb, '$[*].number')::text               as phone_fts,
+    count(distinct t.id) filter (where t.done_date is null)                   as nb_tasks
 from public.contacts co
     left join public.tasks t    on co.id = t.contact_id
     left join public.companies c on co.company_id = c.id
@@ -115,10 +97,10 @@ group by co.id, c.name;
 create or replace view public.deals_summary with (security_invoker = on) as
 select
     d.*,
-    comp.name                                                                                          as company_name,
-    lower(immutable_unaccent(coalesce(comp.name, '')))                                                 as company_name_search,
-    coalesce(string_agg((c.first_name || ' ' || c.last_name), ' '), '')                               as contact_names,
-    lower(immutable_unaccent(coalesce(string_agg((c.first_name || ' ' || c.last_name), ' '), '')))    as contact_names_search
+    comp.name                                                                                                          as company_name,
+    replace(lower(immutable_unaccent(coalesce(comp.name, ''))), ' ', '')                                                as company_name_search,
+    coalesce(string_agg((c.first_name || ' ' || c.last_name), ' '), '')                                                as contact_names,
+    replace(lower(immutable_unaccent(coalesce(string_agg((c.first_name || ' ' || c.last_name), ' '), ''))), ' ', '')    as contact_names_search
 from public.deals d
     left join public.contacts c on c.id = any(d.contact_ids)
     left join public.companies comp on comp.id = d.company_id


### PR DESCRIPTION
## Summary
- Strip spaces from `_search` generated columns in DB so `"soclinic"` matches `"So Clinic"`
- Frontend search normalization also strips spaces when querying `_search` columns
- Affects all autocomplete/search: companies, contacts, deals

Closes #39

## Test plan
- [ ] Search "SoClinic" in deal creation → "SO CLINIC" / "So Clinic" appears
- [ ] Search "So Clinic" (with space) still works
- [ ] Accent-insensitive search still works (e.g. "Clément" → "Clement")
- [ ] Contact search and deal search unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)