### PR TITLE
fix(search): contacts autocomplete in deal form (v1.9.43)

### DIFF
--- a/src/components/atomic-crm/providers/supabase/dataProvider.ts
+++ b/src/components/atomic-crm/providers/supabase/dataProvider.ts
@@ -70,7 +70,7 @@ const getDataProviderWithCustomMethods = () => {
         ])(params);
         return baseDataProvider.getList("companies_summary", searchParams);
       }
-      if (resource === "contacts") {
+      if (resource === "contacts" || resource === "contacts_summary") {
         const searchParams = applyFullTextSearch([
           "first_name",
           "last_name",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "v1.9.42";
+export const APP_VERSION = "v1.9.43";


### PR DESCRIPTION
## Summary
- `ReferenceArrayInput` for contacts uses `reference="contacts_summary"` which bypassed `applyFullTextSearch` (only matched `"contacts"`)
- The `q` filter was sent raw to PostgREST → 0 results when typing in the contact autocomplete in deal creation
- Fix: match both `"contacts"` and `"contacts_summary"` in the data provider

Closes #39

## Test plan
- [ ] Create a deal → type "HEN" in contact autocomplete → "Henaff" appears
- [ ] Company autocomplete still works
- [ ] Contact search in other views unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)