### PR TITLE
fix+feat: Opportunités gagnées, images AI Assist, kill-switch SSO Google (v1.9.46)

### DIFF
--- a/src/components/atomic-crm/assist/NoshoAssistChat.tsx
+++ b/src/components/atomic-crm/assist/NoshoAssistChat.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { Loader2, Send, Sparkles } from "lucide-react";
+import { ImagePlus, Loader2, Send, Sparkles, X } from "lucide-react";
 import {
   Sheet,
   SheetContent,
@@ -19,6 +19,9 @@ const TYPE_LABEL: Record<"bug" | "feature" | "question", string> = {
   question: "Question",
 };
 
+const MAX_ASSIST_IMAGES = 3;
+const MAX_ASSIST_IMAGE_SIZE = 5 * 1024 * 1024; // 5 MB
+
 export function NoshoAssistChat() {
   const { isOpen, initialMessage, close } = useAssist();
   const {
@@ -34,8 +37,13 @@ export function NoshoAssistChat() {
 
   const [input, setInput] = useState("");
   const [submitted, setSubmitted] = useState<{ url?: string } | null>(null);
+  const [images, setImages] = useState<{ file: File; previewUrl: string }[]>(
+    [],
+  );
+  const [imageError, setImageError] = useState<string | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Reset state on open, optionally seeding the textarea with a message.
   useEffect(() => {
@@ -43,10 +51,25 @@ export function NoshoAssistChat() {
     reset();
     setSubmitted(null);
     setInput(initialMessage ?? "");
+    setImages((prev) => {
+      prev.forEach((img) => URL.revokeObjectURL(img.previewUrl));
+      return [];
+    });
+    setImageError(null);
     // Focus shortly after the sheet animation starts.
     const t = setTimeout(() => textareaRef.current?.focus(), 200);
     return () => clearTimeout(t);
   }, [isOpen, initialMessage, reset]);
+
+  // Revoke preview URLs when the component unmounts.
+  useEffect(() => {
+    return () => {
+      images.forEach((img) => URL.revokeObjectURL(img.previewUrl));
+    };
+    // Intentional: cleanup on unmount only. Per-change cleanup is handled
+    // in the add/remove handlers.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Auto-scroll on new messages.
   useEffect(() => {
@@ -70,10 +93,49 @@ export function NoshoAssistChat() {
   };
 
   const handleSubmit = async () => {
-    const result = await submitDraft();
+    const result = await submitDraft(images.map((img) => img.file));
     if (result?.ok) {
       setSubmitted({ url: result.issueUrl });
+      images.forEach((img) => URL.revokeObjectURL(img.previewUrl));
+      setImages([]);
     }
+  };
+
+  const handlePickImages = (files: FileList | null) => {
+    setImageError(null);
+    if (!files || files.length === 0) return;
+    const selected = Array.from(files);
+    const tooBig = selected.find((f) => f.size > MAX_ASSIST_IMAGE_SIZE);
+    if (tooBig) {
+      setImageError(
+        `"${tooBig.name}" dépasse la taille max (${MAX_ASSIST_IMAGE_SIZE / (1024 * 1024)} Mo).`,
+      );
+      return;
+    }
+    setImages((prev) => {
+      const remaining = MAX_ASSIST_IMAGES - prev.length;
+      if (remaining <= 0) {
+        setImageError(`Maximum ${MAX_ASSIST_IMAGES} images.`);
+        return prev;
+      }
+      const next = selected.slice(0, remaining).map((file) => ({
+        file,
+        previewUrl: URL.createObjectURL(file),
+      }));
+      if (selected.length > remaining) {
+        setImageError(`Maximum ${MAX_ASSIST_IMAGES} images.`);
+      }
+      return [...prev, ...next];
+    });
+  };
+
+  const handleRemoveImage = (index: number) => {
+    setImages((prev) => {
+      const img = prev[index];
+      if (img) URL.revokeObjectURL(img.previewUrl);
+      return prev.filter((_, i) => i !== index);
+    });
+    setImageError(null);
   };
 
   return (
@@ -187,7 +249,64 @@ export function NoshoAssistChat() {
         </div>
 
         <div className="border-t p-3">
+          {images.length > 0 && (
+            <div className="flex flex-wrap gap-2 mb-2">
+              {images.map((img, i) => (
+                <div
+                  key={img.previewUrl}
+                  className="relative w-14 h-14 rounded-md overflow-hidden border border-border"
+                >
+                  <img
+                    src={img.previewUrl}
+                    alt={img.file.name}
+                    className="w-full h-full object-cover"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveImage(i)}
+                    className="absolute top-0.5 right-0.5 rounded-full bg-black/60 text-white p-0.5 hover:bg-black/80 transition-colors"
+                    aria-label={`Retirer ${img.file.name}`}
+                  >
+                    <X className="w-3 h-3" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+          {imageError && (
+            <p className="text-[10px] text-destructive mb-1.5 px-1">
+              {imageError}
+            </p>
+          )}
           <div className="flex items-end gap-2">
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              multiple
+              className="hidden"
+              onChange={(e) => {
+                handlePickImages(e.target.files);
+                e.target.value = "";
+              }}
+            />
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={
+                isSending ||
+                !!submitted ||
+                isSubmitting ||
+                images.length >= MAX_ASSIST_IMAGES
+              }
+              className="shrink-0"
+              aria-label="Joindre une image"
+              title="Joindre une capture ou une image"
+            >
+              <ImagePlus className="w-4 h-4" />
+            </Button>
             <Textarea
               ref={textareaRef}
               value={input}
@@ -209,7 +328,9 @@ export function NoshoAssistChat() {
             </Button>
           </div>
           <p className="text-[10px] text-muted-foreground mt-1.5 px-1">
-            Entrée pour envoyer · Maj+Entrée pour aller à la ligne
+            Entrée pour envoyer · Maj+Entrée pour aller à la ligne · Jusqu'à{" "}
+            {MAX_ASSIST_IMAGES} images (max{" "}
+            {MAX_ASSIST_IMAGE_SIZE / (1024 * 1024)} Mo)
           </p>
         </div>
       </SheetContent>

--- a/src/components/atomic-crm/assist/useAssistChat.ts
+++ b/src/components/atomic-crm/assist/useAssistChat.ts
@@ -1,5 +1,10 @@
 import { useCallback, useRef, useState } from "react";
 import { getSupabaseClient } from "../providers/supabase/supabase";
+import { ATTACHMENTS_BUCKET } from "../providers/commons/attachments";
+
+// Long enough for the team to triage the ticket; short enough that a
+// leaked URL eventually expires.
+const ASSIST_ATTACHMENT_TTL_SECONDS = 60 * 60 * 24 * 30; // 30 days
 
 export type ChatMessage = {
   role: "user" | "assistant";
@@ -29,6 +34,28 @@ function generateSessionId(): string {
     return `nosho-${crypto.randomUUID()}`;
   }
   return `nosho-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+async function uploadAssistImages(files: File[]): Promise<string[]> {
+  if (files.length === 0) return [];
+  const client = getSupabaseClient();
+  const urls: string[] = [];
+  for (const file of files) {
+    const ext = file.name.includes(".") ? `.${file.name.split(".").pop()}` : "";
+    const path = `assist/${crypto.randomUUID()}${ext}`;
+    const { error: upErr } = await client.storage
+      .from(ATTACHMENTS_BUCKET)
+      .upload(path, file, { contentType: file.type });
+    if (upErr) throw new Error(`Upload échoué : ${upErr.message}`);
+    const { data: signed, error: signErr } = await client.storage
+      .from(ATTACHMENTS_BUCKET)
+      .createSignedUrl(path, ASSIST_ATTACHMENT_TTL_SECONDS);
+    if (signErr || !signed?.signedUrl) {
+      throw new Error(`Signature d'URL échouée : ${signErr?.message ?? ""}`);
+    }
+    urls.push(signed.signedUrl);
+  }
+  return urls;
 }
 
 export function useAssistChat() {
@@ -102,37 +129,47 @@ export function useAssistChat() {
     [isSending],
   );
 
-  const submitDraft = useCallback(async (): Promise<SubmitResponse | null> => {
-    if (!draft || isSubmitting) return null;
-    setError(null);
-    setIsSubmitting(true);
-    try {
-      const { data, error: invokeError } =
-        await getSupabaseClient().functions.invoke<SubmitResponse>(
-          "assist-submit",
-          {
-            body: {
-              sessionId: sessionIdRef.current,
-              draft,
-              currentRoute:
-                typeof window !== "undefined"
-                  ? window.location.pathname + window.location.hash
-                  : "",
-              userAgent:
-                typeof navigator !== "undefined" ? navigator.userAgent : "",
-              transcript: messages,
+  const submitDraft = useCallback(
+    async (images?: File[]): Promise<SubmitResponse | null> => {
+      if (!draft || isSubmitting) return null;
+      setError(null);
+      setIsSubmitting(true);
+      try {
+        const attachmentUrls = await uploadAssistImages(images ?? []);
+        const summary = attachmentUrls.length
+          ? `${draft.summary}\n\n---\n**Captures d'écran :**\n\n${attachmentUrls
+              .map((url, i) => `![Capture ${i + 1}](${url})`)
+              .join("\n\n")}`
+          : draft.summary;
+
+        const { data, error: invokeError } =
+          await getSupabaseClient().functions.invoke<SubmitResponse>(
+            "assist-submit",
+            {
+              body: {
+                sessionId: sessionIdRef.current,
+                draft: { ...draft, summary },
+                currentRoute:
+                  typeof window !== "undefined"
+                    ? window.location.pathname + window.location.hash
+                    : "",
+                userAgent:
+                  typeof navigator !== "undefined" ? navigator.userAgent : "",
+                transcript: messages,
+              },
             },
-          },
-        );
-      if (invokeError) throw invokeError;
-      return data ?? null;
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-      return null;
-    } finally {
-      setIsSubmitting(false);
-    }
-  }, [draft, messages, isSubmitting]);
+          );
+        if (invokeError) throw invokeError;
+        return data ?? null;
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+        return null;
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [draft, messages, isSubmitting],
+  );
 
   return {
     messages,

--- a/src/components/atomic-crm/dashboard/KPICards.tsx
+++ b/src/components/atomic-crm/dashboard/KPICards.tsx
@@ -241,15 +241,18 @@ function WonDealsCard({ deals }: { deals: Deal[] | undefined }) {
 
   const { wonThisMonth, wonLastMonthCount } = useMemo(() => {
     const wonDeals = deals?.filter((d) => d.stage === "closed-won") ?? [];
+    const wonDate = (d: Deal) => d.won_at ?? d.updated_at;
     return {
       wonThisMonth: wonDeals.filter((d) => {
-        if (!d.updated_at) return false;
-        const u = new Date(d.updated_at);
+        const raw = wonDate(d);
+        if (!raw) return false;
+        const u = new Date(raw);
         return u.getFullYear() === cy && u.getMonth() === cm;
       }),
       wonLastMonthCount: wonDeals.filter((d) => {
-        if (!d.updated_at) return false;
-        const u = new Date(d.updated_at);
+        const raw = wonDate(d);
+        if (!raw) return false;
+        const u = new Date(raw);
         return u.getFullYear() === ly && u.getMonth() === lm;
       }).length,
     };

--- a/src/components/atomic-crm/login/LoginPage.tsx
+++ b/src/components/atomic-crm/login/LoginPage.tsx
@@ -7,13 +7,11 @@ import { TextInput } from "@/components/admin/text-input";
 import { Notification } from "@/components/admin/notification";
 import { useConfigurationContext } from "@/components/atomic-crm/root/ConfigurationContext.tsx";
 import { SSOAuthButton } from "./SSOAuthButton";
+import { GOOGLE_SSO_ENABLED } from "./googleSsoFeatureFlag";
 
 export const LoginPage = (props: { redirectTo?: string }) => {
-  const {
-    title,
-    googleWorkplaceDomain,
-    disableEmailPasswordAuthentication,
-  } = useConfigurationContext();
+  const { title, googleWorkplaceDomain, disableEmailPasswordAuthentication } =
+    useConfigurationContext();
   const { redirectTo } = props;
   const [loading, setLoading] = useState(false);
   const hasDisplayedRecoveryNotification = useRef(false);
@@ -34,7 +32,10 @@ export const LoginPage = (props: { redirectTo?: string }) => {
     searchParams.delete("passwordRecoveryEmailSent");
     const nextSearch = searchParams.toString();
     navigate(
-      { pathname: location.pathname, search: nextSearch ? `?${nextSearch}` : "" },
+      {
+        pathname: location.pathname,
+        search: nextSearch ? `?${nextSearch}` : "",
+      },
       { replace: true },
     );
   }, [location.pathname, location.search, navigate, notify]);
@@ -54,9 +55,12 @@ export const LoginPage = (props: { redirectTo?: string }) => {
           {
             type: "error",
             messageArgs: {
-              _: typeof error === "string"
-                ? error
-                : error && error.message ? error.message : undefined,
+              _:
+                typeof error === "string"
+                  ? error
+                  : error && error.message
+                    ? error.message
+                    : undefined,
             },
           },
         );
@@ -69,20 +73,25 @@ export const LoginPage = (props: { redirectTo?: string }) => {
       <div className="fixed inset-0 pointer-events-none overflow-hidden">
         <div
           className="absolute -top-24 -left-24 w-[380px] h-[380px] rounded-full opacity-40"
-          style={{ background: "radial-gradient(circle, #FF9B54 0%, transparent 70%)" }}
+          style={{
+            background: "radial-gradient(circle, #FF9B54 0%, transparent 70%)",
+          }}
         />
         <div
           className="absolute top-1/2 -right-32 w-[300px] h-[300px] rounded-full opacity-20"
-          style={{ background: "radial-gradient(circle, #92B592 0%, transparent 70%)" }}
+          style={{
+            background: "radial-gradient(circle, #92B592 0%, transparent 70%)",
+          }}
         />
         <div
           className="absolute -bottom-16 left-1/3 w-[220px] h-[220px] rounded-full opacity-15"
-          style={{ background: "radial-gradient(circle, #FF9B54 0%, transparent 70%)" }}
+          style={{
+            background: "radial-gradient(circle, #FF9B54 0%, transparent 70%)",
+          }}
         />
       </div>
 
       <div className="relative z-10 grid w-full max-w-[950px] mx-auto px-6 lg:grid-cols-2 lg:gap-12 min-h-screen lg:min-h-0 lg:items-center">
-
         {/* ── Panneau gauche ── */}
         <div className="hidden lg:flex flex-col py-16 pr-8">
           {/* Logo */}
@@ -123,11 +132,18 @@ export const LoginPage = (props: { redirectTo?: string }) => {
                 <div
                   key={f.title}
                   className="rounded-xl p-4 border border-gray-100 shadow-sm"
-                  style={{ backgroundColor: "rgba(255,255,255,0.8)", backdropFilter: "blur(8px)" }}
+                  style={{
+                    backgroundColor: "rgba(255,255,255,0.8)",
+                    backdropFilter: "blur(8px)",
+                  }}
                 >
                   <span className="text-xl">{f.icon}</span>
-                  <p className="mt-1.5 font-semibold text-gray-900 text-sm">{f.title}</p>
-                  <p className="mt-0.5 text-gray-500 text-xs leading-relaxed">{f.desc}</p>
+                  <p className="mt-1.5 font-semibold text-gray-900 text-sm">
+                    {f.title}
+                  </p>
+                  <p className="mt-0.5 text-gray-500 text-xs leading-relaxed">
+                    {f.desc}
+                  </p>
                 </div>
               ))}
             </div>
@@ -160,7 +176,10 @@ export const LoginPage = (props: { redirectTo?: string }) => {
           {/* Card formulaire */}
           <div
             className="w-full max-w-sm rounded-3xl border border-gray-100 p-8 shadow-xl"
-            style={{ backgroundColor: "rgba(255,255,255,0.9)", backdropFilter: "blur(12px)" }}
+            style={{
+              backgroundColor: "rgba(255,255,255,0.9)",
+              backdropFilter: "blur(12px)",
+            }}
           >
             <div className="mb-8">
               <h2 className="text-2xl font-bold text-gray-900">
@@ -222,9 +241,12 @@ export const LoginPage = (props: { redirectTo?: string }) => {
               </Form>
             )}
 
-            {googleWorkplaceDomain && (
+            {GOOGLE_SSO_ENABLED && googleWorkplaceDomain && (
               <div className="mt-4">
-                <SSOAuthButton className="w-full rounded-xl" domain={googleWorkplaceDomain}>
+                <SSOAuthButton
+                  className="w-full rounded-xl"
+                  domain={googleWorkplaceDomain}
+                >
                   Continuer avec Google
                 </SSOAuthButton>
               </div>

--- a/src/components/atomic-crm/login/SignupPage.tsx
+++ b/src/components/atomic-crm/login/SignupPage.tsx
@@ -14,6 +14,7 @@ import { LoginSkeleton } from "./LoginSkeleton";
 import { Notification } from "@/components/admin/notification";
 import { ConfirmationRequired } from "./ConfirmationRequired";
 import { SSOAuthButton } from "./SSOAuthButton";
+import { GOOGLE_SSO_ENABLED } from "./googleSsoFeatureFlag";
 
 export const SignupPage = () => {
   const queryClient = useQueryClient();
@@ -159,7 +160,7 @@ export const SignupPage = () => {
                   "Create account"
                 )}
               </Button>
-              {googleWorkplaceDomain ? (
+              {GOOGLE_SSO_ENABLED && googleWorkplaceDomain ? (
                 <SSOAuthButton
                   className="w-full"
                   domain={googleWorkplaceDomain}

--- a/src/components/atomic-crm/login/googleSsoFeatureFlag.ts
+++ b/src/components/atomic-crm/login/googleSsoFeatureFlag.ts
@@ -1,0 +1,7 @@
+// Kill-switch for the Google Workspace SSO buttons on login/signup.
+// The Supabase project currently has no SAML SSO provider registered
+// (`GET /config/auth/sso/providers` returns an empty list), so clicking
+// the button always fails. Set to true once the SAML flow is configured
+// (see doc/src/content/docs/developers/sso.mdx) and the Supabase project
+// has an SSO provider for the intended domain.
+export const GOOGLE_SSO_ENABLED = false;

--- a/src/components/atomic-crm/types.ts
+++ b/src/components/atomic-crm/types.ts
@@ -125,6 +125,7 @@ export type Deal = {
   archived_at?: string;
   expected_closing_date: string;
   trial_start_date?: string;
+  won_at?: string;
   sales_id: Identifier;
   index: number;
 } & Pick<RaRecord, "id">;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "v1.9.44";
+export const APP_VERSION = "v1.9.45";

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "v1.9.45";
+export const APP_VERSION = "v1.9.46";

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "v1.9.43";
+export const APP_VERSION = "v1.9.44";

--- a/supabase/migrations/20260417120000_deals_won_at.sql
+++ b/supabase/migrations/20260417120000_deals_won_at.sql
@@ -1,0 +1,28 @@
+-- Track the date a deal transitioned to closed-won (decoupled from updated_at).
+ALTER TABLE public.deals ADD COLUMN IF NOT EXISTS won_at date;
+
+CREATE OR REPLACE FUNCTION public.set_deal_won_at() RETURNS trigger
+    LANGUAGE plpgsql
+    SET search_path TO 'public'
+AS $$
+BEGIN
+  IF NEW.stage = 'closed-won' AND (OLD.stage IS DISTINCT FROM 'closed-won') THEN
+    NEW.won_at := NOW();
+  ELSIF NEW.stage != 'closed-won' AND OLD.stage = 'closed-won' THEN
+    NEW.won_at := NULL;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS deal_stage_won_at ON public.deals;
+CREATE TRIGGER deal_stage_won_at
+    BEFORE UPDATE ON public.deals
+    FOR EACH ROW
+    WHEN (OLD.stage IS DISTINCT FROM NEW.stage)
+    EXECUTE FUNCTION public.set_deal_won_at();
+
+-- Backfill: set won_at for existing closed-won deals without a date
+UPDATE public.deals
+SET won_at = updated_at::date
+WHERE stage = 'closed-won' AND won_at IS NULL;

--- a/supabase/schemas/01_tables.sql
+++ b/supabase/schemas/01_tables.sql
@@ -75,7 +75,8 @@ create table public.deals (
     archived_at timestamp with time zone,
     expected_closing_date date,
     sales_id bigint,
-    index smallint
+    index smallint,
+    won_at date
 );
 
 create table public.deal_notes (

--- a/supabase/schemas/02_functions.sql
+++ b/supabase/schemas/02_functions.sql
@@ -436,3 +436,17 @@ BEGIN
   RETURN NEW;
 END;
 $$;
+
+CREATE OR REPLACE FUNCTION "public"."set_deal_won_at"() RETURNS "trigger"
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public'
+    AS $$
+BEGIN
+  IF NEW.stage = 'closed-won' AND (OLD.stage IS DISTINCT FROM 'closed-won') THEN
+    NEW.won_at := NOW();
+  ELSIF NEW.stage != 'closed-won' AND OLD.stage = 'closed-won' THEN
+    NEW.won_at := NULL;
+  END IF;
+  RETURN NEW;
+END;
+$$;

--- a/supabase/schemas/04_triggers.sql
+++ b/supabase/schemas/04_triggers.sql
@@ -20,6 +20,13 @@ create or replace trigger set_deal_sales_id_trigger
     before insert on public.deals
     for each row execute function public.set_sales_id_default();
 
+-- Auto-set deal.won_at when stage transitions to/from closed-won
+create or replace trigger deal_stage_won_at
+    before update on public.deals
+    for each row
+    when (old.stage is distinct from new.stage)
+    execute function public.set_deal_won_at();
+
 create or replace trigger set_deal_notes_sales_id_trigger
     before insert on public.deal_notes
     for each row execute function public.set_sales_id_default();


### PR DESCRIPTION
## Summary

Trois correctifs du jour regroupés :

### #33 — fix(dashboard): Opportunités gagnées comptées par `won_at`
- Le widget *Opportunités gagnées* comptait les deals `closed-won` via `updated_at`, manquant les deals gagnés dans le mois mais non réédités. Compteur bloqué à 0.
- Bascule sur la colonne dédiée `deals.won_at` (posée par le trigger `deal_stage_won_at` déjà présent en prod).
- `schemas/` resynchronisés + migration idempotente (`ADD COLUMN IF NOT EXISTS`, `CREATE OR REPLACE FUNCTION`). Déjà appliquée sur prod via `make supabase-push`.
- Vérifié : 2 deals d'avril 2026 (`Nicolas Roussey` won_at=2026-04-14, `Dr PIETRI` won_at=2026-04-03) remontent bien.

Closes #33

### #37 — feat(assist): joindre des images dans l'AI Assist
- Nouveau bouton "Joindre une image" dans le chat AI Assist (jusqu'à 3 images, 5 Mo/chacune, `image/*`).
- Upload dans le bucket `attachments` (préfixe `assist/`) au moment du submit ; URLs signées 30 jours.
- URLs markdown insérées dans le body de l'issue GitHub → rendu image auto (camo cache le contenu côté GitHub).

Closes #37

### fix(login): kill-switch pour le bouton Google Workspace SSO
- Benjamin (utilisateur) tombait sur une erreur rouge systématique en tentant "Continuer avec Google" : le projet Supabase n'a aucun provider SAML SSO configuré (`GET /config/auth/sso/providers` → liste vide).
- Feature flag hardcodé `GOOGLE_SSO_ENABLED = false` (voir `src/components/atomic-crm/login/googleSsoFeatureFlag.ts`) pour masquer le bouton sur `/login` et `/sign-up` tant que le flux SAML n'est pas déployé (voir `doc/src/content/docs/developers/sso.mdx`).
- Reverse : passer la constante à `true` une fois le provider SSO ajouté dans la console Supabase.

## Test plan
- [ ] Dashboard : compteur "Opportunités gagnées ce mois" à 2
- [ ] Passage `trial` ↔ `closed-won` : `won_at` change correctement
- [ ] AI Assist : bouton image, preview, retrait, envoi → images visibles dans l'issue créée
- [ ] `/login` et `/sign-up` : plus de bouton "Continuer avec Google"
- [ ] `make typecheck` → 0 erreurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)