### PR TITLE
feat(deals): en-têtes de colonnes Kanban figés au scroll (v1.9.47)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -490,6 +490,10 @@
           "type": "registry:component"
         },
         {
+          "path": "src/components/atomic-crm/login/googleSsoFeatureFlag.ts",
+          "type": "registry:component"
+        },
+        {
           "path": "src/components/atomic-crm/login/StartPage.tsx",
           "type": "registry:component"
         },

--- a/src/components/atomic-crm/deals/DealColumn.tsx
+++ b/src/components/atomic-crm/deals/DealColumn.tsx
@@ -16,8 +16,8 @@ export const DealColumn = ({
 
   const { dealStages } = useConfigurationContext();
   return (
-    <div className="flex-1 pb-8">
-      <div className="flex flex-col items-center">
+    <div className="flex-1 min-w-[220px] pb-8">
+      <div className="sticky top-0 z-10 flex flex-col items-center bg-background py-2 shadow-[0_4px_6px_-6px_rgba(0,0,0,0.15)]">
         <h3 className="text-base font-medium">
           {findDealLabel(dealStages, stage)} ({deals.length})
         </h3>

--- a/src/components/atomic-crm/deals/DealListContent.tsx
+++ b/src/components/atomic-crm/deals/DealListContent.tsx
@@ -37,7 +37,9 @@ export const DealListContent = () => {
       const saved = localStorage.getItem(storageKey);
       if (saved) {
         const parsed = JSON.parse(saved) as string[];
-        const valid = parsed.filter((s) => dealStages.some((ds) => ds.value === s));
+        const valid = parsed.filter((s) =>
+          dealStages.some((ds) => ds.value === s),
+        );
         if (valid.length > 0) return new Set(valid);
       }
     } catch {}
@@ -110,7 +112,7 @@ export const DealListContent = () => {
 
     // persist the changes and invalidate all deal list caches (all views)
     updateDealStage(sourceDeal, destinationDeal, dataProvider).then(() => {
-      queryClient.invalidateQueries({ queryKey: ['deals', 'getList'] });
+      queryClient.invalidateQueries({ queryKey: ["deals", "getList"] });
     });
   };
 
@@ -168,7 +170,7 @@ export const DealListContent = () => {
 
       {/* Kanban columns */}
       <DragDropContext onDragEnd={onDragEnd}>
-        <div className="flex gap-4 overflow-x-auto pb-4">
+        <div className="flex gap-4 overflow-auto pb-4 h-[calc(100dvh-14rem)] min-h-[420px]">
           {visibleDealStages.map((stage) => (
             <DealColumn
               stage={stage.value}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "v1.9.47";
+export const APP_VERSION = "v1.9.48";

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "v1.9.46";
+export const APP_VERSION = "v1.9.47";


### PR DESCRIPTION
## Summary

Closes #43

Quand on descend pour voir les opportunités en bas du pipeline, les titres de colonnes (Lead, Qualifié, Suivi, etc.) sortaient de l'écran. Le Kanban a désormais sa propre hauteur bornée et chaque en-tête de colonne est sticky-top relatif à ce conteneur.

- `overflow-x-auto` → `overflow-auto h-[calc(100dvh-14rem)] min-h-[420px]` (le scroll se fait maintenant dans le Kanban, pas dans la page)
- `sticky top-0 bg-background` + shadow discrète sur l'en-tête de chaque DealColumn
- `min-w-[220px]` par colonne pour garder les cartes lisibles quand il y a beaucoup d'étapes visibles

## Portée

L'issue #43 mentionne "Opportunités, Contacts, Sociétés…". Seules les Opportunités ont des en-têtes de colonnes (le Kanban). Les listes Contacts et Sociétés sont des listes de cartes/rangées (`ContactListContent`, `CompanyList/GridList`) — pas de colonnes à figer. Si Benjamin voulait figer la barre de filtres/actions en haut, c'est un autre sujet (à rouvrir si besoin).

## Test plan

- [ ] `/deals` : scroller verticalement → les titres de colonnes restent visibles en haut
- [ ] Drag & drop d'une carte entre colonnes toujours fonctionnel (hello-pangea/dnd auto-scroll)
- [ ] Scroll horizontal OK quand beaucoup d'étapes sont visibles
- [ ] `make typecheck` → 0 erreurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)