### PR TITLE
feat(dashboard): lien cliquable vers contact + opportunité dans les tâches (v1.9.50)

### DIFF
--- a/src/components/atomic-crm/tasks/Task.tsx
+++ b/src/components/atomic-crm/tasks/Task.tsx
@@ -1,7 +1,14 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { MoreVertical } from "lucide-react";
-import { useDeleteWithUndoController, useNotify, useUpdate } from "ra-core";
-import { useEffect, useState } from "react";
+import {
+  type Identifier,
+  useDeleteWithUndoController,
+  useGetList,
+  useNotify,
+  useUpdate,
+} from "ra-core";
+import { useEffect, useState, type MouseEvent } from "react";
+import { Link } from "react-router";
 import { ReferenceField } from "@/components/admin/reference-field";
 import { DateField } from "@/components/admin/date-field";
 import { Button } from "@/components/ui/button";
@@ -14,7 +21,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 
 import { useConfigurationContext } from "../root/ConfigurationContext";
-import type { Contact, Task as TData } from "../types";
+import type { Contact, Deal, Task as TData } from "../types";
 import { TaskEdit } from "./TaskEdit";
 import { TaskEditSheet } from "./TaskEditSheet";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -109,24 +116,26 @@ export const Task = ({
               due&nbsp;
               <DateField source="due_date" record={task} showDate showTime />
               {showContact && (
-                <ReferenceField<TData, Contact>
-                  source="contact_id"
-                  reference="contacts"
-                  record={task}
-                  link="show"
-                  className="inline text-sm text-muted-foreground"
-                  render={({ referenceRecord }) => {
-                    if (!referenceRecord) return null;
-                    return (
-                      <>
-                        {" "}
-                        (Re:&nbsp;
-                        {referenceRecord?.first_name}{" "}
-                        {referenceRecord?.last_name})
-                      </>
-                    );
-                  }}
-                />
+                <>
+                  {" · "}
+                  <ReferenceField<TData, Contact>
+                    source="contact_id"
+                    reference="contacts"
+                    record={task}
+                    link="show"
+                    className="inline text-sm [&_a]:text-foreground [&_a]:hover:underline"
+                    render={({ referenceRecord }) => {
+                      if (!referenceRecord) return null;
+                      return (
+                        <>
+                          {referenceRecord?.first_name}{" "}
+                          {referenceRecord?.last_name}
+                        </>
+                      );
+                    }}
+                  />
+                  <TaskDealLink contactId={task.contact_id} />
+                </>
               )}
             </div>
           </div>
@@ -201,6 +210,54 @@ export const Task = ({
       ) : (
         <TaskEdit taskId={task.id} open={openEdit} close={handleCloseEdit} />
       )}
+    </>
+  );
+};
+
+const stopPropagation = (e: MouseEvent) => e.stopPropagation();
+
+const TaskDealLink = ({ contactId }: { contactId: Identifier }) => {
+  const { data: deals, isPending } = useGetList<Deal>(
+    "deals",
+    {
+      pagination: { page: 1, perPage: 3 },
+      sort: { field: "updated_at", order: "DESC" },
+      filter: {
+        "contact_ids@cs": `{${contactId}}`,
+        "archived_at@is": null,
+      },
+    },
+    { enabled: contactId != null },
+  );
+
+  if (isPending || !deals || deals.length === 0) return null;
+
+  if (deals.length === 1) {
+    const deal = deals[0];
+    return (
+      <>
+        {" · "}
+        <Link
+          to={`/deals/${deal.id}/show`}
+          onClick={stopPropagation}
+          className="text-foreground hover:underline"
+        >
+          {deal.name}
+        </Link>
+      </>
+    );
+  }
+
+  return (
+    <>
+      {" · "}
+      <Link
+        to={`/contacts/${contactId}/show`}
+        onClick={stopPropagation}
+        className="text-foreground hover:underline"
+      >
+        {deals.length} opportunités
+      </Link>
     </>
   );
 };

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "v1.9.48";
+export const APP_VERSION = "v1.9.50";


### PR DESCRIPTION
## Summary

Closes #44

Sur le tableau de bord, chaque tâche affichait "(Re: Prénom Nom)" en gris muet sans aucun indice visuel de lien cliquable. Benjamin n'arrivait pas à sauter directement à l'opportunité ou au contact associés.

- Le nom du contact est désormais rendu en foreground color avec underline au hover (c'était déjà un `<Link>` sous-jacent via `ReferenceField link="show"`, juste invisible visuellement).
- Nouveau composant `TaskDealLink` qui va chercher les deals non archivés liés au contact de la tâche :
  - 1 deal → lien direct vers la page du deal
  - N deals → lien "N opportunités" vers la page contact (qui les liste toutes)
  - 0 deal → rien

Le rendu passe de :
> due 2026-04-20 (Re: Jean Dupont)

à :
> due 2026-04-20 · **Jean Dupont** · **Contrat ACME**

## Notes techniques

- Tasks n'ont pas de `deal_id` direct — elles sont rattachées à un contact via `contact_id`. La requête utilise `contact_ids@cs: {id}` (opérateur PostgREST `cs` sur la colonne array `deals.contact_ids`).
- Requête par tâche, mais React Query dédupe par contact, donc coût raisonnable (5-10 tâches par dashboard).

## Test plan

- [ ] `/` dashboard : noms de contacts cliquables avec hover underline
- [ ] Tâche dont le contact a 1 seule opportunité → clic sur le nom du deal ouvre `/deals/{id}/show`
- [ ] Tâche dont le contact a plusieurs opportunités → "N opportunités" ouvre la page contact
- [ ] Tâche dont le contact n'a aucun deal actif → pas de lien deal (juste le nom du contact)
- [ ] `make typecheck` → 0 erreurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)