### PR TITLE
feat(layout): notification de nouvelle version (v1.9.51)

### DIFF
--- a/src/components/atomic-crm/layout/Layout.tsx
+++ b/src/components/atomic-crm/layout/Layout.tsx
@@ -10,6 +10,7 @@ import { NoshoAssistChat } from "../assist/NoshoAssistChat";
 import { NoshoAssistFAB } from "../assist/NoshoAssistFAB";
 import { useConfigurationLoader } from "../root/useConfigurationLoader";
 import Header from "./Header";
+import { VersionUpdateToast } from "./VersionUpdateToast";
 
 const SentryErrorBoundary = Sentry.withErrorBoundary(
   ({ children }: { children: ReactNode }) => <>{children}</>,
@@ -38,6 +39,7 @@ export const Layout = ({ children }: { children: ReactNode }) => {
       </main>
       <NoshoAssistFAB />
       <NoshoAssistChat />
+      <VersionUpdateToast />
       <Notification />
     </AssistProvider>
   );

--- a/src/components/atomic-crm/layout/VersionUpdateToast.tsx
+++ b/src/components/atomic-crm/layout/VersionUpdateToast.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import { RefreshCw, X } from "lucide-react";
+import { useVersionCheck } from "./useVersionCheck";
+
+export function VersionUpdateToast() {
+  const { hasUpdate, latestVersion, reload } = useVersionCheck();
+  const [dismissed, setDismissed] = useState<string | null>(null);
+
+  if (!hasUpdate || dismissed === latestVersion) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed bottom-22 right-6 z-[60] max-w-xs animate-in fade-in slide-in-from-bottom-4 duration-300"
+    >
+      <div className="flex items-start gap-3 rounded-lg border border-border bg-popover text-popover-foreground shadow-lg shadow-black/20 p-3 pr-2">
+        <span className="relative flex h-2.5 w-2.5 mt-1.5 shrink-0">
+          <span className="absolute inline-flex h-full w-full rounded-full bg-[var(--nosho-green)] opacity-75 animate-ping" />
+          <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-[var(--nosho-green)]" />
+        </span>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium leading-tight">
+            Nouvelle version disponible
+          </p>
+          {latestVersion && (
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {latestVersion} — rechargez pour en profiter.
+            </p>
+          )}
+          <button
+            type="button"
+            onClick={reload}
+            className="mt-2 inline-flex items-center gap-1.5 rounded-md bg-[var(--nosho-green)] hover:bg-[var(--nosho-green-dark)] text-white text-xs font-medium px-2.5 py-1.5 transition-colors cursor-pointer"
+          >
+            <RefreshCw className="w-3 h-3" />
+            Recharger
+          </button>
+        </div>
+        <button
+          type="button"
+          onClick={() => setDismissed(latestVersion)}
+          aria-label="Ignorer"
+          className="text-muted-foreground hover:text-foreground transition-colors rounded p-1 cursor-pointer"
+        >
+          <X className="w-3.5 h-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/atomic-crm/layout/useVersionCheck.ts
+++ b/src/components/atomic-crm/layout/useVersionCheck.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useState } from "react";
+import { APP_VERSION } from "../../../version";
+
+const POLL_INTERVAL_MS = 5 * 60 * 1000;
+
+type VersionPayload = { version?: string };
+
+async function fetchRemoteVersion(): Promise<string | null> {
+  try {
+    const url = `${import.meta.env.BASE_URL}version.json?t=${Date.now()}`;
+    const res = await fetch(url, { cache: "no-store" });
+    if (!res.ok) return null;
+    const data: VersionPayload = await res.json();
+    return typeof data.version === "string" ? data.version : null;
+  } catch {
+    return null;
+  }
+}
+
+export function useVersionCheck() {
+  const [latestVersion, setLatestVersion] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const check = async () => {
+      const remote = await fetchRemoteVersion();
+      if (cancelled || !remote) return;
+      if (remote !== APP_VERSION) {
+        setLatestVersion(remote);
+      }
+    };
+
+    check();
+    const interval = setInterval(check, POLL_INTERVAL_MS);
+
+    const onVisible = () => {
+      if (document.visibilityState === "visible") check();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
+  }, []);
+
+  const reload = useCallback(() => {
+    window.location.reload();
+  }, []);
+
+  return {
+    hasUpdate: latestVersion !== null,
+    currentVersion: APP_VERSION,
+    latestVersion,
+    reload,
+  };
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "v1.9.50";
+export const APP_VERSION = "v1.9.51";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,6 @@
 import path from "node:path";
+import { readFileSync } from "node:fs";
+import type { Plugin } from "vite";
 import { defineConfig } from "vite";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
@@ -6,11 +8,40 @@ import { visualizer } from "rollup-plugin-visualizer";
 import createHtmlPlugin from "vite-plugin-simple-html";
 import { VitePWA } from "vite-plugin-pwa";
 
+function readAppVersion(): string {
+  const src = readFileSync(path.resolve(__dirname, "src/version.ts"), "utf-8");
+  const match = src.match(/APP_VERSION\s*=\s*"([^"]+)"/);
+  return match?.[1] ?? "unknown";
+}
+
+function versionJsonPlugin(): Plugin {
+  const payload = () =>
+    JSON.stringify({ version: readAppVersion(), builtAt: Date.now() });
+  return {
+    name: "nosho-version-json",
+    configureServer(server) {
+      server.middlewares.use("/version.json", (_req, res) => {
+        res.setHeader("Content-Type", "application/json");
+        res.setHeader("Cache-Control", "no-store");
+        res.end(payload());
+      });
+    },
+    generateBundle() {
+      this.emitFile({
+        type: "asset",
+        fileName: "version.json",
+        source: payload(),
+      });
+    },
+  };
+}
+
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
     react(),
     tailwindcss(),
+    versionJsonPlugin(),
     visualizer({
       open: process.env.NODE_ENV !== "CI",
       filename: "./dist/stats.html",


### PR DESCRIPTION
## Summary
- Ajoute un toast discret en bas à droite (au-dessus de la FAB Nosho AI Assist) avec pastille verte pulsante + bouton "Recharger" quand une nouvelle version est déployée
- Un plugin Vite lit `src/version.ts` et expose `/version.json` : en dev via middleware, au build via `emitFile`
- Hook `useVersionCheck` qui poll toutes les 5 min et au `visibilitychange`, avec cache-bust

## Test plan
- [x] `make typecheck` passe
- [x] `/version.json` servi correctement en dev (retourne la version courante)
- [ ] Après déploiement Coolify : vérifier que `https://crm.nosho.cc/version.json` retourne bien la nouvelle version
- [ ] Garder un onglet ouvert sur la version N, déployer N+1, attendre ≤5 min (ou refocus) : le toast doit apparaître

🤖 Generated with [Claude Code](https://claude.com/claude-code)