### PR TITLE
fix(deals): sociétés trouvées dans la création d'opportunité (v1.9.52)

### DIFF
--- a/src/components/atomic-crm/deals/DealInputs.tsx
+++ b/src/components/atomic-crm/deals/DealInputs.tsx
@@ -86,10 +86,7 @@ const DealLinkedToInputs = ({
     const type = newType === ALL_TYPES ? "" : newType;
     onCompanyTypeFilterChange(type);
     setValue("company_type", type || null);
-    setValue("company_id", null);
   };
-
-  const companyFilter = companyTypeFilter ? { type: companyTypeFilter } : {};
 
   return (
     <div className="flex flex-col gap-4 flex-1">
@@ -115,11 +112,7 @@ const DealLinkedToInputs = ({
         </Select>
       </div>
 
-      <ReferenceInput
-        source="company_id"
-        reference="companies"
-        filter={companyFilter}
-      >
+      <ReferenceInput source="company_id" reference="companies">
         <AutocompleteCompanyInput
           validate={required()}
           defaultType={companyTypeFilter || undefined}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "v1.9.51";
+export const APP_VERSION = "v1.9.52";


### PR DESCRIPTION
## Summary
- Closes #51
- Le sélecteur "Vue" dans le formulaire d'opportunité filtrait l'autocomplete des sociétés par `company.type`. Résultat : une société existante mais d'un autre type (ou sans type) était invisible, l'utilisateur pensait qu'elle n'existait pas et risquait de la créer en doublon.
- Le `company_type` d'une opportunité est volontairement indépendant du `type` de la société (cf. migration `20260330120000_deals_company_type.sql`), donc l'autocomplete doit lister toutes les sociétés.
- `defaultType` reste passé à `AutocompleteCompanyInput` pour que les sociétés créées inline soient taguées correctement.

## Test plan
- [ ] Ouvrir une vue Kanban personnalisée (ex. "Prospect")
- [ ] Cliquer "Nouvelle opportunité"
- [ ] Taper le nom d'une société dont le `type` diffère de la vue (ou est `null`)
- [ ] Vérifier que la société apparaît dans l'autocomplete et qu'aucun doublon n'est proposé
- [ ] Vérifier qu'en tapant un nom inédit, "Créer %{item}" pré-tague la nouvelle société avec la vue courante

🤖 Generated with [Claude Code](https://claude.com/claude-code)