### PR TITLE
fix(settings): ignorer les étapes/catégories orphelines lors de la validation

### DIFF
--- a/src/components/atomic-crm/settings/SettingsPage.test.ts
+++ b/src/components/atomic-crm/settings/SettingsPage.test.ts
@@ -89,4 +89,33 @@ describe("validateItemsInUse", () => {
       validateItemsInUse(items, deals, "category", "categories"),
     ).toContain("copywriting");
   });
+
+  it("ignores orphan deal values not present in the baseline config", () => {
+    // Scenario: a deal has stage="opportunity" in the DB, but that stage was
+    // never part of the saved config. Adding a new stage should not trigger
+    // a removal error for the orphan value.
+    const items = [
+      { value: "won", label: "Won" },
+      { value: "lost", label: "Lost" },
+      { value: "new-stage", label: "New Stage" },
+    ];
+    const baseline = new Set(["won", "lost"]);
+    expect(validateItemsInUse(items, deals, "stage", "stages", baseline)).toBe(
+      undefined,
+    );
+  });
+
+  it("still flags removed values that were in the baseline", () => {
+    const items = [{ value: "won", label: "Won" }];
+    const baseline = new Set(["won", "lost", "opportunity"]);
+    const result = validateItemsInUse(
+      items,
+      deals,
+      "stage",
+      "stages",
+      baseline,
+    );
+    expect(result).toContain("lost");
+    expect(result).toContain("opportunity");
+  });
 });

--- a/src/components/atomic-crm/settings/SettingsPage.tsx
+++ b/src/components/atomic-crm/settings/SettingsPage.tsx
@@ -44,6 +44,13 @@ export const validateItemsInUse = (
   deals: RaRecord[] | undefined,
   fieldName: string,
   displayName: string,
+  /**
+   * Slugs that were present in the last-saved configuration. When provided,
+   * a deal is only flagged as "still using a removed value" if its value was
+   * in this set — orphan values that exist in the DB but not in the saved
+   * config don't block the user from editing other settings.
+   */
+  baselineValues?: Set<string>,
 ) => {
   if (!items) return undefined;
   // Check for duplicate slugs
@@ -63,9 +70,13 @@ export const validateItemsInUse = (
   const inUse = [
     ...new Set(
       deals
-        .filter(
-          (deal) => deal[fieldName] && !values.has(deal[fieldName] as string),
-        )
+        .filter((deal) => {
+          const value = deal[fieldName] as string | undefined | null;
+          if (!value) return false;
+          if (values.has(value)) return false;
+          if (baselineValues && !baselineValues.has(value)) return false;
+          return true;
+        })
         .map((deal) => deal[fieldName] as string),
     ),
   ];
@@ -171,20 +182,37 @@ const SettingsFormFields = () => {
   const dealStages = watch("dealStages");
   const dealPipelineStatuses: string[] = watch("dealPipelineStatuses") ?? [];
 
+  const config = useConfigurationContext();
+
   const { data: deals } = useGetList("deals", {
     pagination: { page: 1, perPage: 1000 },
   });
 
+  const baselineStageValues = useMemo(
+    () => new Set(config.dealStages.map((s) => s.value)),
+    [config.dealStages],
+  );
+  const baselineCategoryValues = useMemo(
+    () => new Set(config.dealCategories.map((c) => c.value)),
+    [config.dealCategories],
+  );
+
   const validateDealStages = useCallback(
     (stages: { value: string; label: string }[] | undefined) =>
-      validateItemsInUse(stages, deals, "stage", "stages"),
-    [deals],
+      validateItemsInUse(stages, deals, "stage", "stages", baselineStageValues),
+    [deals, baselineStageValues],
   );
 
   const validateDealCategories = useCallback(
     (categories: { value: string; label: string }[] | undefined) =>
-      validateItemsInUse(categories, deals, "category", "categories"),
-    [deals],
+      validateItemsInUse(
+        categories,
+        deals,
+        "category",
+        "categories",
+        baselineCategoryValues,
+      ),
+    [deals, baselineCategoryValues],
   );
 
   return (
@@ -221,7 +249,9 @@ const SettingsFormFields = () => {
             <TextInput source="title" label="Titre de l'application" />
             <div className="flex gap-8">
               <div className="flex flex-col items-center gap-1">
-                <p className="text-sm text-muted-foreground">Logo (mode clair)</p>
+                <p className="text-sm text-muted-foreground">
+                  Logo (mode clair)
+                </p>
                 <ImageEditorField
                   source="lightModeLogo"
                   width={100}
@@ -231,7 +261,9 @@ const SettingsFormFields = () => {
                 />
               </div>
               <div className="flex flex-col items-center gap-1">
-                <p className="text-sm text-muted-foreground">Logo (mode sombre)</p>
+                <p className="text-sm text-muted-foreground">
+                  Logo (mode sombre)
+                </p>
                 <ImageEditorField
                   source="darkModeLogo"
                   width={100}
@@ -550,7 +582,8 @@ const CustomViewsSection = () => {
                         const isAllowed =
                           isOpenToAll ||
                           view.allowedUserIds?.includes(sale.id as number);
-                        const initials = `${sale.first_name?.[0] ?? ""}${sale.last_name?.[0] ?? ""}`.toUpperCase();
+                        const initials =
+                          `${sale.first_name?.[0] ?? ""}${sale.last_name?.[0] ?? ""}`.toUpperCase();
                         return (
                           <button
                             key={sale.id}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "v1.9.52";
+export const APP_VERSION = "v1.9.54";


### PR DESCRIPTION
## Summary

- Fixes #53 : l'ajout d'une nouvelle étape (ex. « Proposition envoyée ») dans Paramètres > Opportunités échouait avec une erreur de type « Impossible de supprimer étapes encore utilisés par des affaires ».
- **Cause racine** : le validateur comparait les étapes du formulaire aux valeurs de `deal.stage` présentes en base. En prod, plusieurs opportunités référencent des valeurs qui ne sont plus dans la config sauvegardée (`opportunity`, `d-mo-rdv`, anciennes catégories `ui-design`, `print-project`…). Le validateur les traitait comme « supprimées » et bloquait **toute** sauvegarde des paramètres, y compris l'ajout d'une nouvelle étape.
- **Correctif** : `validateItemsInUse` accepte maintenant un `baselineValues` (valeurs de la dernière config sauvegardée). Une valeur n'est signalée comme « encore utilisée » que si elle faisait **réellement** partie de la baseline — les valeurs orphelines en base ne bloquent plus l'édition.
- Appliqué aux deux validateurs (étapes + catégories). Deux tests unitaires ajoutés.

Version bumpée à **v1.9.54** par le hook pre-commit.

## Test plan

- [x] `make typecheck` passe
- [x] Tests unitaires `validateItemsInUse` passent (y compris les deux nouveaux cas)
- [ ] Sur le preview Coolify : aller dans Paramètres → Opportunités → Étapes, ajouter « Proposition envoyée », sauvegarder → plus d'erreur
- [ ] Vérifier qu'on ne peut toujours pas supprimer une étape qui est réellement utilisée (ex. `lead`) : l'erreur doit s'afficher correctement

🤖 Generated with [Claude Code](https://claude.com/claude-code)