### PR TITLE
fix(google): connecter un compte Google échouait systématiquement (v1.9.66)

### DIFF
--- a/src/components/atomic-crm/google/GoogleOAuthCallback.tsx
+++ b/src/components/atomic-crm/google/GoogleOAuthCallback.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { useNavigate } from "react-router";
+import { useNavigate, useSearchParams } from "react-router";
 import { useDataProvider, useNotify } from "ra-core";
 import { Loader2, CheckCircle2, XCircle } from "lucide-react";
 import type { CrmDataProvider } from "../providers/types";
@@ -10,6 +10,7 @@ export const GoogleOAuthCallback = () => {
   const dataProvider = useDataProvider<CrmDataProvider>();
   const notify = useNotify();
   const invalidate = useInvalidateGoogleStatus();
+  const [searchParams] = useSearchParams();
   const [status, setStatus] = useState<"loading" | "success" | "error">(
     "loading",
   );
@@ -19,9 +20,8 @@ export const GoogleOAuthCallback = () => {
     if (exchangedRef.current) return;
     exchangedRef.current = true;
 
-    const params = new URLSearchParams(window.location.search);
-    const code = params.get("code");
-    const error = params.get("error");
+    const code = searchParams.get("code");
+    const error = searchParams.get("error");
 
     if (error || !code) {
       setStatus("error");
@@ -43,7 +43,7 @@ export const GoogleOAuthCallback = () => {
         notify(err.message || "Erreur de connexion Google", { type: "error" });
         setTimeout(() => navigate("/connectors"), 2000);
       });
-  }, [dataProvider, navigate, notify, invalidate]);
+  }, [dataProvider, navigate, notify, invalidate, searchParams]);
 
   return (
     <div className="flex items-center justify-center min-h-screen">

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "v1.9.65";
+export const APP_VERSION = "v1.9.66";


### PR DESCRIPTION
## Summary

- Le callback Google OAuth affichait toujours "Authentification Google annulée" empêchant Benjamin et tout autre utilisateur de connecter leur compte Google.
- L'app utilise `HashRouter` (défaut ra-core). `main.tsx` réécrit l'URL `/google-oauth-callback?code=XXX` renvoyée par Google en `/#/google-oauth-callback?code=XXX`. Après cette réécriture, `window.location.search` est vide — le code est dans le hash.
- `GoogleOAuthCallback` lisait `window.location.search`, donc `code = null` → affichage immédiat de l'erreur sans même appeler l'edge function.
- Fix : utiliser `useSearchParams()` de react-router qui parse correctement les params depuis le hash.

## Test plan

- [ ] Après déploiement, aller sur `/connectors`
- [ ] Cliquer **Connecter Google** → login Google → accepter les scopes
- [ ] Vérifier le retour sur `/connectors` avec badge **Connecté** vert et l'email affiché
- [ ] Vérifier que le widget Google Calendar apparaît sur le dashboard
- [ ] Demander à Benjamin de tester la connexion