### PR TITLE
fix(deals): opportunités masquées au-delà de 100 sur le Kanban (#61)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -518,6 +518,14 @@
           "type": "registry:component"
         },
         {
+          "path": "src/components/atomic-crm/layout/useVersionCheck.ts",
+          "type": "registry:component"
+        },
+        {
+          "path": "src/components/atomic-crm/layout/VersionUpdateToast.tsx",
+          "type": "registry:component"
+        },
+        {
           "path": "src/components/atomic-crm/layout/TopToolbar.tsx",
           "type": "registry:component"
         },
@@ -574,6 +582,10 @@
           "type": "registry:component"
         },
         {
+          "path": "src/components/atomic-crm/deals/useGenerateProposal.ts",
+          "type": "registry:component"
+        },
+        {
           "path": "src/components/atomic-crm/deals/stages.ts",
           "type": "registry:component"
         },
@@ -591,6 +603,10 @@
         },
         {
           "path": "src/components/atomic-crm/deals/OnlyMineInput.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "src/components/atomic-crm/deals/GenerateProposalAction.tsx",
           "type": "registry:component"
         },
         {

--- a/src/components/atomic-crm/deals/DealList.tsx
+++ b/src/components/atomic-crm/deals/DealList.tsx
@@ -50,7 +50,7 @@ const DealList = () => {
 
   return (
     <List
-      perPage={100}
+      perPage={1000}
       filter={{ "archived_at@is": null, "company_type@is": null }}
       title={false}
       sort={{ field: "index", order: "DESC" }}

--- a/src/components/atomic-crm/deals/DealListContent.tsx
+++ b/src/components/atomic-crm/deals/DealListContent.tsx
@@ -233,7 +233,7 @@ const updateDealStage = async (
     // Fetch all the deals in this stage (because the list may be filtered, but we need to update even non-filtered deals)
     const { data: columnDeals } = await dataProvider.getList("deals", {
       sort: { field: "index", order: "ASC" },
-      pagination: { page: 1, perPage: 100 },
+      pagination: { page: 1, perPage: 1000 },
       filter: { stage: source.stage },
     });
     const destinationIndex = destination.index ?? columnDeals.length + 1;
@@ -298,12 +298,12 @@ const updateDealStage = async (
       await Promise.all([
         dataProvider.getList("deals", {
           sort: { field: "index", order: "ASC" },
-          pagination: { page: 1, perPage: 100 },
+          pagination: { page: 1, perPage: 1000 },
           filter: { stage: source.stage },
         }),
         dataProvider.getList("deals", {
           sort: { field: "index", order: "ASC" },
-          pagination: { page: 1, perPage: 100 },
+          pagination: { page: 1, perPage: 1000 },
           filter: { stage: destination.stage },
         }),
       ]);

--- a/src/components/atomic-crm/deals/DealListForView.tsx
+++ b/src/components/atomic-crm/deals/DealListForView.tsx
@@ -76,7 +76,7 @@ export const DealListForView = () => {
     >
       <List
         resource="deals"
-        perPage={100}
+        perPage={1000}
         filter={{
           "archived_at@is": null,
           // Only apply the company_type constraint when the view actually

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "v1.9.66";
+export const APP_VERSION = "v1.9.68";


### PR DESCRIPTION
## Résumé

Fixe [#61](https://github.com/nosho-org/nosho-crm/issues/61) — certaines opportunités (ex : *SO CLINIC Le Perreux*) disparaissaient des colonnes du Kanban et ne réapparaissaient qu'après une recherche par mot-clé suivie d'un déplacement.

## Cause racine

Le Kanban des opportunités utilisait `perPage={100}` avec `pagination={null}` :
- `src/components/atomic-crm/deals/DealList.tsx:53`
- `src/components/atomic-crm/deals/DealListForView.tsx:79`

Avec un tri `index DESC`, dès qu'il y a plus de 100 opportunités non archivées, les plus anciennes (à `index` bas) sont tronquées par PostgREST sans avertissement UI, donc absentes des colonnes. Une recherche par mot-clé réduit le résultat sous le cap → l'opportunité réapparaît ; un déplacement la met à jour avec un nouvel `index` (et invalide le cache), la replaçant temporairement dans le top 100.

Les requêtes de réordonnancement dans `updateDealStage` (`DealListContent.tsx`) avaient le même cap caché — un stage à plus de 100 opportunités donnait des index incohérents.

## Correctif

`perPage` passe de `100` → `1000` partout. C'est la valeur exacte de `max_rows` côté PostgREST (`supabase/config.toml`), donc le plafond serveur naturel.

## Test plan

- [ ] Vérifier sur preview que toutes les opportunités non archivées apparaissent dans leurs colonnes
- [ ] Vérifier que *SO CLINIC Le Perreux* est visible sans recherche
- [ ] Drag-and-drop entre colonnes toujours fonctionnel
- [ ] Pas de régression sur les vues custom (`/views/:viewId`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)