### PR TITLE
fix(proposal): pointer l'edge function sur doc.nosho.org (v1.9.69)

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "v1.9.68";
+export const APP_VERSION = "v1.9.69";

--- a/supabase/functions/generate-proposal/index.ts
+++ b/supabase/functions/generate-proposal/index.ts
@@ -9,8 +9,7 @@ import {
 import { createErrorResponse } from "../_shared/utils.ts";
 import { buildProposalPayload } from "./buildPayload.ts";
 
-const NOSHO_API_URL =
-  "https://nosho-doc-generator.nosho-ai.workers.dev/api/proposals";
+const NOSHO_API_URL = "https://doc.nosho.org/api/proposals";
 const NOSHO_TIMEOUT_MS = 15000;
 
 type RequestBody = {


### PR DESCRIPTION
## Summary
- L'edge function `generate-proposal` appelait `https://nosho-doc-generator.nosho-ai.workers.dev/api/proposals`, qui n'existe pas.
- Le worker `nosho-doc-generator` est en réalité servi sur le domaine custom `doc.nosho.org` (cf. `wrangler.toml` du repo `nosho-org/nosho-doc-generator`).
- Résultat côté UI : Cloudflare renvoyait 404/1042, mappé en `nosho_error` → toast "Impossible de générer la proposition".

## Vérification
- `curl https://doc.nosho.org/api/proposals` avec la clé `NOSHO_API_KEY` renvoie `201 {id, editUrl, publicUrl, apiUrl}` comme attendu.
- Edge function redéployée en production (version 2 — `make supabase-deploy` non nécessaire pour ce changement seul, j'ai déployé `generate-proposal` directement).
- `make typecheck` ✅

## Test plan
- [ ] Ouvrir une opportunité, cliquer "Générer proposition", choisir un contact, valider.
- [ ] Confirmer l'apparition des deux liens "Édition" et "Version client" sans message d'erreur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)