### PR TITLE
fix(pwa): forcer l'installation de la nouvelle version au clic Recharger (v1.9.70)

### DIFF
--- a/src/components/atomic-crm/layout/VersionUpdateToast.tsx
+++ b/src/components/atomic-crm/layout/VersionUpdateToast.tsx
@@ -1,12 +1,21 @@
 import { useState } from "react";
-import { RefreshCw, X } from "lucide-react";
+import { RefreshCw } from "lucide-react";
 import { useVersionCheck } from "./useVersionCheck";
 
 export function VersionUpdateToast() {
   const { hasUpdate, latestVersion, reload } = useVersionCheck();
-  const [dismissed, setDismissed] = useState<string | null>(null);
+  const [reloading, setReloading] = useState(false);
 
-  if (!hasUpdate || dismissed === latestVersion) return null;
+  if (!hasUpdate) return null;
+
+  const handleReload = async () => {
+    setReloading(true);
+    try {
+      await reload();
+    } catch {
+      setReloading(false);
+    }
+  };
 
   return (
     <div
@@ -14,7 +23,7 @@ export function VersionUpdateToast() {
       aria-live="polite"
       className="fixed bottom-22 right-6 z-[60] max-w-xs animate-in fade-in slide-in-from-bottom-4 duration-300"
     >
-      <div className="flex items-start gap-3 rounded-lg border border-border bg-popover text-popover-foreground shadow-lg shadow-black/20 p-3 pr-2">
+      <div className="flex items-start gap-3 rounded-lg border border-border bg-popover text-popover-foreground shadow-lg shadow-black/20 p-3">
         <span className="relative flex h-2.5 w-2.5 mt-1.5 shrink-0">
           <span className="absolute inline-flex h-full w-full rounded-full bg-[var(--nosho-green)] opacity-75 animate-ping" />
           <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-[var(--nosho-green)]" />
@@ -30,21 +39,16 @@ export function VersionUpdateToast() {
           )}
           <button
             type="button"
-            onClick={reload}
-            className="mt-2 inline-flex items-center gap-1.5 rounded-md bg-[var(--nosho-green)] hover:bg-[var(--nosho-green-dark)] text-white text-xs font-medium px-2.5 py-1.5 transition-colors cursor-pointer"
+            onClick={handleReload}
+            disabled={reloading}
+            className="mt-2 inline-flex items-center gap-1.5 rounded-md bg-[var(--nosho-green)] hover:bg-[var(--nosho-green-dark)] disabled:opacity-70 disabled:cursor-wait text-white text-xs font-medium px-2.5 py-1.5 transition-colors cursor-pointer"
           >
-            <RefreshCw className="w-3 h-3" />
-            Recharger
+            <RefreshCw
+              className={`w-3 h-3 ${reloading ? "animate-spin" : ""}`}
+            />
+            {reloading ? "Mise à jour…" : "Recharger"}
           </button>
         </div>
-        <button
-          type="button"
-          onClick={() => setDismissed(latestVersion)}
-          aria-label="Ignorer"
-          className="text-muted-foreground hover:text-foreground transition-colors rounded p-1 cursor-pointer"
-        >
-          <X className="w-3.5 h-3.5" />
-        </button>
       </div>
     </div>
   );

--- a/src/components/atomic-crm/layout/useVersionCheck.ts
+++ b/src/components/atomic-crm/layout/useVersionCheck.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { useRegisterSW } from "virtual:pwa-register/react";
 import { APP_VERSION } from "../../../version";
 
 const POLL_INTERVAL_MS = 5 * 60 * 1000;
@@ -17,8 +18,33 @@ async function fetchRemoteVersion(): Promise<string | null> {
   }
 }
 
+async function nukeCachesAndReload() {
+  try {
+    if ("serviceWorker" in navigator) {
+      const regs = await navigator.serviceWorker.getRegistrations();
+      await Promise.all(regs.map((r) => r.unregister()));
+    }
+    if ("caches" in window) {
+      const keys = await caches.keys();
+      await Promise.all(keys.map((k) => caches.delete(k)));
+    }
+  } finally {
+    window.location.reload();
+  }
+}
+
 export function useVersionCheck() {
   const [latestVersion, setLatestVersion] = useState<string | null>(null);
+
+  const { updateServiceWorker } = useRegisterSW({
+    immediate: true,
+    onRegisteredSW(_swUrl, registration) {
+      if (!registration) return;
+      setInterval(() => {
+        registration.update().catch(() => {});
+      }, POLL_INTERVAL_MS);
+    },
+  });
 
   useEffect(() => {
     let cancelled = false;
@@ -46,9 +72,13 @@ export function useVersionCheck() {
     };
   }, []);
 
-  const reload = useCallback(() => {
-    window.location.reload();
-  }, []);
+  const reload = useCallback(async () => {
+    try {
+      await updateServiceWorker(true);
+    } catch {
+      await nukeCachesAndReload();
+    }
+  }, [updateServiceWorker]);
 
   return {
     hasUpdate: latestVersion !== null,

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "v1.9.69";
+export const APP_VERSION = "v1.9.70";

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/react" />


### PR DESCRIPTION
## Summary
- Le bouton « Recharger » du toast de nouvelle version appelait `window.location.reload()` seul, mais le service worker Workbox restait en cache et continuait à servir les anciens assets — particulièrement visible dans un onglet Chrome jamais fermé / app installée
- Utilise désormais `useRegisterSW` de `vite-plugin-pwa` (déjà installé) → `updateServiceWorker(true)` fait `skipWaiting()` + reload propre
- Fallback « nucléaire » (`unregister()` + `caches.delete()` + reload) si le SW n'est pas dispo
- Suppression du bouton X (Ignorer) pour ne pas laisser un user sur une vieille version
- Polling `version.json` toutes les 5 min conservé pour la détection rapide ; en bonus `registration.update()` est aussi appelé sur le même intervalle côté SW

## Test plan
- [ ] Déploiement Coolify preview OK
- [ ] Ouvrir l'app dans un onglet Chrome
- [ ] Attendre qu'une nouvelle version soit déployée (ou bumper et redéployer)
- [ ] Vérifier que le toast s'affiche au bout d'≤5 min
- [ ] Cliquer « Recharger » → voir « Mise à jour… » puis l'app revient sur la nouvelle version
- [ ] Le toast ne réapparaît pas après reload