### PR TITLE
fix(pwa): bouton Recharger qui mouline à l'infini

### DIFF
--- a/src/components/atomic-crm/layout/useVersionCheck.ts
+++ b/src/components/atomic-crm/layout/useVersionCheck.ts
@@ -19,6 +19,11 @@ async function fetchRemoteVersion(): Promise<string | null> {
 }
 
 async function nukeCachesAndReload() {
+  // Safety net: if any of the SW/cache APIs hangs (rare but observed in the
+  // wild), reload anyway after 3s so the user is never stuck.
+  const fallbackTimer = window.setTimeout(() => {
+    window.location.reload();
+  }, 3000);
   try {
     if ("serviceWorker" in navigator) {
       const regs = await navigator.serviceWorker.getRegistrations();
@@ -28,7 +33,10 @@ async function nukeCachesAndReload() {
       const keys = await caches.keys();
       await Promise.all(keys.map((k) => caches.delete(k)));
     }
+  } catch {
+    // Ignore — fallback timer or the finally reload will fire.
   } finally {
+    window.clearTimeout(fallbackTimer);
     window.location.reload();
   }
 }

--- a/src/components/atomic-crm/layout/useVersionCheck.ts
+++ b/src/components/atomic-crm/layout/useVersionCheck.ts
@@ -36,7 +36,9 @@ async function nukeCachesAndReload() {
 export function useVersionCheck() {
   const [latestVersion, setLatestVersion] = useState<string | null>(null);
 
-  const { updateServiceWorker } = useRegisterSW({
+  // Periodic SW update check keeps the precache warm in the background.
+  // The click handler does not depend on its result — see reload() below.
+  useRegisterSW({
     immediate: true,
     onRegisteredSW(_swUrl, registration) {
       if (!registration) return;
@@ -72,13 +74,11 @@ export function useVersionCheck() {
     };
   }, []);
 
-  const reload = useCallback(async () => {
-    try {
-      await updateServiceWorker(true);
-    } catch {
-      await nukeCachesAndReload();
-    }
-  }, [updateServiceWorker]);
+  // updateServiceWorker(true) silently no-ops when there is no waiting SW —
+  // a frequent race because version.json polling and SW update polling are
+  // unsynchronized intervals. Always nuke + reload so the spinner actually
+  // resolves into a fresh page.
+  const reload = useCallback(() => nukeCachesAndReload(), []);
 
   return {
     hasUpdate: latestVersion !== null,

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "v1.9.77";
+export const APP_VERSION = "v1.9.78";

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "v1.9.76";
+export const APP_VERSION = "v1.9.77";


### PR DESCRIPTION
## Cause racine

Le bouton Recharger appelait \`updateServiceWorker(true)\` de \`vite-plugin-pwa\`, qui **résout silencieusement sa promise** quand aucun Service Worker n'est en état \`waiting\`. Le polling de \`version.json\` et le polling \`registration.update()\` tournent sur deux \`setInterval\` désynchronisés : il est fréquent que \`version.json\` détecte une nouvelle version **avant** que le SW ait téléchargé/installé la sienne. Dans ce cas, le clic ne déclenchait ni \`SKIP_WAITING\` ni \`controllerchange\` ni reload — la promise résout, le spinner reste figé, et le \`catch\` (qui aurait dû déclencher \`nukeCachesAndReload\`) n'était jamais atteint puisque \`updateServiceWorker\` ne throw pas.

## Fix

- Au clic, on bascule systématiquement sur le chemin nucléaire fiable : \`unregister\` SW + \`caches.delete()\` + \`location.reload()\`.
- Filet de sécurité : un \`setTimeout\` de 3 s force le reload même si l'une des API SW/caches gèle dans un état corrompu.

## Coût

Un re-téléchargement du précache Workbox par déploiement (~1 MB). Négligeable.

## Limites connues

Les utilisateurs **actuellement coincés** sur une version antérieure à celle-ci ne se déverrouilleront pas automatiquement — leur bundle JS en mémoire reste celui d'avant. Ils devront faire un hard reload (Cmd+Shift+R) **une fois** pour récupérer le nouveau code. À partir de ce moment, le bouton fonctionne pour tous les déploiements suivants.

## Test plan

- [ ] Merger sur main → Coolify déploie v1.9.78 sur \`crm.nosho.cc\`.
- [ ] Sur un onglet déjà ouvert : Cmd+Shift+R une fois pour passer en v1.9.78.
- [ ] Déclencher un commit pour ré-incrémenter la version → toast réapparaît.
- [ ] Cliquer Recharger → la page recharge en ~1-2 s sur la nouvelle version, sans spinner figé.