### PR TITLE
fix(deals): prevent malformed config crash

### DIFF
--- a/src/components/atomic-crm/deals/stages.ts
+++ b/src/components/atomic-crm/deals/stages.ts
@@ -7,7 +7,7 @@ export const getDealsByStage = (
   unorderedDeals: Deal[],
   dealStages: ConfigurationContextValue["dealStages"],
 ) => {
-  if (!dealStages) return {};
+  if (!dealStages?.length) return {};
   const dealsByStage: Record<Deal["stage"], Deal[]> = unorderedDeals.reduce(
     (acc, deal) => {
       // if deal has a stage that does not exist in configuration, assign it to the first stage

--- a/src/components/atomic-crm/root/ConfigurationContext.test.ts
+++ b/src/components/atomic-crm/root/ConfigurationContext.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import { getDealsByStage } from "../deals/stages";
+import { mergeConfigurationWithDefaults } from "./ConfigurationContext";
+import { defaultConfiguration } from "./defaultConfiguration";
+
+describe("mergeConfigurationWithDefaults", () => {
+  it("falls back to default deal stages when persisted configuration has none", () => {
+    const config = mergeConfigurationWithDefaults({
+      dealStages: [],
+    });
+
+    expect(config.dealStages).toEqual(defaultConfiguration.dealStages);
+  });
+
+  it("keeps the deals board reducer from crashing with malformed deal stage config", () => {
+    const config = mergeConfigurationWithDefaults({
+      dealStages: null as any,
+    });
+
+    expect(() =>
+      getDealsByStage(
+        [
+          {
+            id: 1,
+            name: "Broken config deal",
+            company_id: 1,
+            contact_ids: [],
+            category: "api",
+            stage: "unknown-stage",
+            description: "",
+            amount: 1000,
+            created_at: "2026-05-16T00:00:00.000Z",
+            updated_at: "2026-05-16T00:00:00.000Z",
+            expected_closing_date: "2026-05-16",
+            sales_id: 1,
+            index: 1,
+          },
+        ],
+        config.dealStages,
+      ),
+    ).not.toThrow();
+  });
+
+  it("does not crash when stage grouping is called before valid stages exist", () => {
+    expect(() =>
+      getDealsByStage(
+        [
+          {
+            id: 1,
+            name: "Early render deal",
+            company_id: 1,
+            contact_ids: [],
+            category: "api",
+            stage: "lead",
+            description: "",
+            amount: 1000,
+            created_at: "2026-05-16T00:00:00.000Z",
+            updated_at: "2026-05-16T00:00:00.000Z",
+            expected_closing_date: "2026-05-16",
+            sales_id: 1,
+            index: 1,
+          },
+        ],
+        [],
+      ),
+    ).not.toThrow();
+  });
+});

--- a/src/components/atomic-crm/root/ConfigurationContext.tsx
+++ b/src/components/atomic-crm/root/ConfigurationContext.tsx
@@ -34,6 +34,57 @@ export interface ConfigurationContextValue {
   alloApiKey?: string;
 }
 
+const nonEmptyArrayOrDefault = <T,>(value: unknown, fallback: T[]): T[] =>
+  Array.isArray(value) && value.length > 0 ? (value as T[]) : fallback;
+
+const arrayOrDefault = <T,>(value: unknown, fallback: T[]): T[] =>
+  Array.isArray(value) ? (value as T[]) : fallback;
+
+export const mergeConfigurationWithDefaults = (
+  config?: Partial<ConfigurationContextValue> | null,
+): ConfigurationContextValue => {
+  const merged = {
+    ...defaultConfiguration,
+    ...(config ?? {}),
+  };
+
+  return {
+    ...merged,
+    companySectors: nonEmptyArrayOrDefault(
+      config?.companySectors,
+      defaultConfiguration.companySectors,
+    ),
+    companyTypes: nonEmptyArrayOrDefault(
+      config?.companyTypes,
+      defaultConfiguration.companyTypes,
+    ),
+    customViews: arrayOrDefault(
+      config?.customViews,
+      defaultConfiguration.customViews,
+    ),
+    dealCategories: nonEmptyArrayOrDefault(
+      config?.dealCategories,
+      defaultConfiguration.dealCategories,
+    ),
+    dealPipelineStatuses: arrayOrDefault(
+      config?.dealPipelineStatuses,
+      defaultConfiguration.dealPipelineStatuses,
+    ),
+    dealStages: nonEmptyArrayOrDefault(
+      config?.dealStages,
+      defaultConfiguration.dealStages,
+    ),
+    noteStatuses: nonEmptyArrayOrDefault(
+      config?.noteStatuses,
+      defaultConfiguration.noteStatuses,
+    ),
+    taskTypes: nonEmptyArrayOrDefault(
+      config?.taskTypes,
+      defaultConfiguration.taskTypes,
+    ),
+  };
+};
+
 export const useConfigurationContext = () => {
   const [config] = useStore<ConfigurationContextValue>(
     CONFIGURATION_STORE_KEY,
@@ -41,7 +92,7 @@ export const useConfigurationContext = () => {
   );
   // Merge with defaults so that missing fields in stored config
   // fall back to default values (e.g. when new settings are added)
-  return useMemo(() => ({ ...defaultConfiguration, ...config }), [config]);
+  return useMemo(() => mergeConfigurationWithDefaults(config), [config]);
 };
 
 export const useConfigurationUpdater = () => {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "v1.9.83";
+export const APP_VERSION = "v1.9.84";


### PR DESCRIPTION
## Problem

Issue #82 reports that opening `/#/deals` can hit the generic "Something went wrong" boundary when the persisted CRM configuration has missing, null, or empty deal stage data.

## Solution

Normalize stored configuration through a shared default merge helper, fall back to default values for critical empty choice arrays like `dealStages`, guard the Kanban stage grouping helper against empty stages, add regression coverage, and bump the app version to `v1.9.84`.

## How To Test

Run `make typecheck`, run `npm run test:unit:app -- src/components/atomic-crm/root/ConfigurationContext.test.ts --run`, and open the demo app at `/#/deals` to verify the view renders without "Something went wrong" or browser console errors.

## Additional Checks

- [x] The **documentation** is up to date
- [x] Tested with **fakerest** provider (see [related documentation](https://github.com/marmelab/atomic-crm/blob/main/doc/developer/data-providers.md))
- [ ] Tested with **Mobile** resolution
