### PR TITLE
fix(assist): send images to chat brain

### DIFF
--- a/src/components/atomic-crm/assist/NoshoAssistChat.tsx
+++ b/src/components/atomic-crm/assist/NoshoAssistChat.tsx
@@ -12,7 +12,11 @@ import { Button } from "@/components/ui/button";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { cn } from "@/lib/utils";
 import { useAssist } from "./assistStore";
-import { useAssistChat, type AssistMode } from "./useAssistChat";
+import {
+  useAssistChat,
+  type AssistAttachment,
+  type AssistMode,
+} from "./useAssistChat";
 
 const TYPE_LABEL: Record<"bug" | "feature" | "question", string> = {
   bug: "Bug",
@@ -76,6 +80,11 @@ export function NoshoAssistChat() {
     reset();
     setSubmitted(null);
     setInput("");
+    setImages((prev) => {
+      prev.forEach((img) => URL.revokeObjectURL(img.previewUrl));
+      return [];
+    });
+    setImageError(null);
   };
 
   // Revoke preview URLs when the component unmounts.
@@ -97,9 +106,19 @@ export function NoshoAssistChat() {
 
   const handleSend = async () => {
     const text = input.trim();
-    if (!text || isSending) return;
-    setInput("");
-    await sendMessage(text);
+    if ((!text && images.length === 0) || isSending) return;
+    const sent = await sendMessage(
+      text,
+      mode === "feedback" ? images.map((img) => img.file) : [],
+    );
+    if (sent) {
+      setInput("");
+      setImages((prev) => {
+        prev.forEach((img) => URL.revokeObjectURL(img.previewUrl));
+        return [];
+      });
+      setImageError(null);
+    }
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -228,7 +247,12 @@ export function NoshoAssistChat() {
           )}
 
           {messages.map((msg, i) => (
-            <MessageBubble key={i} role={msg.role} content={msg.content} />
+            <MessageBubble
+              key={i}
+              role={msg.role}
+              content={msg.content}
+              attachments={msg.attachments}
+            />
           ))}
 
           {isSending && (
@@ -376,7 +400,11 @@ export function NoshoAssistChat() {
               type="button"
               size="icon"
               onClick={handleSend}
-              disabled={!input.trim() || isSending || !!submitted}
+              disabled={
+                (!input.trim() && images.length === 0) ||
+                isSending ||
+                !!submitted
+              }
               className="shrink-0"
             >
               <Send className="w-4 h-4" />
@@ -407,9 +435,11 @@ export function NoshoAssistChat() {
 function MessageBubble({
   role,
   content,
+  attachments = [],
 }: {
   role: "user" | "assistant";
   content: string;
+  attachments?: AssistAttachment[];
 }) {
   // Strip the JSON fence from the assistant display - the parsed draft is
   // already shown as a structured card below the message stream.
@@ -433,6 +463,26 @@ function MessageBubble({
         )}
       >
         {display}
+        {attachments.length > 0 && (
+          <div className="mt-2 grid grid-cols-2 gap-2">
+            {attachments.map((attachment, index) => (
+              <a
+                key={`${attachment.url}-${index}`}
+                href={attachment.url}
+                target="_blank"
+                rel="noreferrer"
+                className="block overflow-hidden rounded-md border border-white/25 bg-black/10"
+                title={attachment.name}
+              >
+                <img
+                  src={attachment.url}
+                  alt={attachment.name || `Capture ${index + 1}`}
+                  className="h-24 w-full object-cover"
+                />
+              </a>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/atomic-crm/assist/useAssistChat.test.ts
+++ b/src/components/atomic-crm/assist/useAssistChat.test.ts
@@ -1,0 +1,30 @@
+import {
+  buildDraftSummaryWithAttachments,
+  formatAssistMessageWithAttachments,
+  type AssistAttachment,
+} from "./useAssistChat";
+
+const attachments: AssistAttachment[] = [
+  {
+    url: "https://example.test/storage/signed/screenshot.png",
+    name: "screenshot.png",
+    type: "image/png",
+    size: 1234,
+  },
+];
+
+describe("useAssistChat attachment formatting", () => {
+  it("adds image URLs to the message forwarded to the assist workflow", () => {
+    expect(
+      formatAssistMessageWithAttachments("Voici le bug", attachments),
+    ).toContain(
+      "screenshot.png: https://example.test/storage/signed/screenshot.png",
+    );
+  });
+
+  it("adds image markdown to the submitted draft summary", () => {
+    expect(buildDraftSummaryWithAttachments("Résumé", attachments)).toContain(
+      "![screenshot.png](https://example.test/storage/signed/screenshot.png)",
+    );
+  });
+});

--- a/src/components/atomic-crm/assist/useAssistChat.ts
+++ b/src/components/atomic-crm/assist/useAssistChat.ts
@@ -11,6 +11,7 @@ export type AssistMode = "feedback" | "crm-action";
 export type ChatMessage = {
   role: "user" | "assistant";
   content: string;
+  attachments?: AssistAttachment[];
 };
 
 export type AssistDraft = {
@@ -18,6 +19,13 @@ export type AssistDraft = {
   title: string;
   summary: string;
   ready: true;
+};
+
+export type AssistAttachment = {
+  url: string;
+  name: string;
+  type: string;
+  size: number;
 };
 
 type AssistChatResponse = {
@@ -35,6 +43,33 @@ type SubmitResponse = {
   issueNumber?: number;
 };
 
+export function formatAssistMessageWithAttachments(
+  message: string,
+  attachments: AssistAttachment[],
+): string {
+  if (attachments.length === 0) return message;
+  const attachmentList = attachments
+    .map((attachment, index) => {
+      const name = attachment.name || `Capture ${index + 1}`;
+      return `- ${name}: ${attachment.url}`;
+    })
+    .join("\n");
+  return `${message}\n\nImages jointes :\n${attachmentList}`;
+}
+
+export function buildDraftSummaryWithAttachments(
+  summary: string,
+  attachments: AssistAttachment[],
+): string {
+  if (attachments.length === 0) return summary;
+  return `${summary}\n\n---\n**Captures d'écran :**\n\n${attachments
+    .map((attachment, i) => {
+      const title = attachment.name || `Capture ${i + 1}`;
+      return `![${title}](${attachment.url})`;
+    })
+    .join("\n\n")}`;
+}
+
 function generateSessionId(): string {
   if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
     return `nosho-${crypto.randomUUID()}`;
@@ -42,10 +77,10 @@ function generateSessionId(): string {
   return `nosho-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
-async function uploadAssistImages(files: File[]): Promise<string[]> {
+async function uploadAssistImages(files: File[]): Promise<AssistAttachment[]> {
   if (files.length === 0) return [];
   const client = getSupabaseClient();
-  const urls: string[] = [];
+  const attachments: AssistAttachment[] = [];
   for (const file of files) {
     const ext = file.name.includes(".") ? `.${file.name.split(".").pop()}` : "";
     const path = `assist/${crypto.randomUUID()}${ext}`;
@@ -59,9 +94,14 @@ async function uploadAssistImages(files: File[]): Promise<string[]> {
     if (signErr || !signed?.signedUrl) {
       throw new Error(`Signature d'URL échouée : ${signErr?.message ?? ""}`);
     }
-    urls.push(signed.signedUrl);
+    attachments.push({
+      url: signed.signedUrl,
+      name: file.name,
+      type: file.type,
+      size: file.size,
+    });
   }
-  return urls;
+  return attachments;
 }
 
 async function sendCrmAction(
@@ -113,30 +153,43 @@ export function useAssistChat(mode: AssistMode = "feedback") {
   }, []);
 
   const sendMessage = useCallback(
-    async (text: string) => {
+    async (text: string, images?: File[]): Promise<boolean> => {
       const trimmed = text.trim();
-      if (!trimmed || isSending) return;
+      const imageFiles = images ?? [];
+      if ((!trimmed && imageFiles.length === 0) || isSending) return false;
 
       setError(null);
-      const userMessage: ChatMessage = { role: "user", content: trimmed };
-      setMessages((prev) => [...prev, userMessage]);
       setIsSending(true);
 
       try {
+        const attachments = await uploadAssistImages(imageFiles);
+        const userContent = trimmed || "Capture d'écran jointe.";
+        const userMessage: ChatMessage = {
+          role: "user",
+          content: userContent,
+          ...(attachments.length > 0 ? { attachments } : {}),
+        };
+        setMessages((prev) => [...prev, userMessage]);
+
         let reply = "";
         let nextDraft: AssistDraft | null = null;
 
         if (mode === "crm-action") {
-          const data = await sendCrmAction(trimmed, sessionIdRef.current);
+          const data = await sendCrmAction(userContent, sessionIdRef.current);
           reply = data.reply ?? "";
         } else {
+          const webhookMessage = formatAssistMessageWithAttachments(
+            userContent,
+            attachments,
+          );
           const { data, error: invokeError } =
             await getSupabaseClient().functions.invoke<AssistChatResponse>(
               "assist-chat",
               {
                 body: {
                   sessionId: sessionIdRef.current,
-                  message: trimmed,
+                  message: webhookMessage,
+                  attachments,
                   context: {
                     currentRoute:
                       typeof window !== "undefined"
@@ -160,8 +213,10 @@ export function useAssistChat(mode: AssistMode = "feedback") {
           setMessages((prev) => [...prev, assistantMessage]);
         }
         if (nextDraft) setDraft(nextDraft);
+        return true;
       } catch (e) {
         setError(e instanceof Error ? e.message : String(e));
+        return false;
       } finally {
         setIsSending(false);
       }
@@ -175,12 +230,15 @@ export function useAssistChat(mode: AssistMode = "feedback") {
       setError(null);
       setIsSubmitting(true);
       try {
-        const attachmentUrls = await uploadAssistImages(images ?? []);
-        const summary = attachmentUrls.length
-          ? `${draft.summary}\n\n---\n**Captures d'écran :**\n\n${attachmentUrls
-              .map((url, i) => `![Capture ${i + 1}](${url})`)
-              .join("\n\n")}`
-          : draft.summary;
+        const newAttachments = await uploadAssistImages(images ?? []);
+        const transcriptAttachments = messages.flatMap(
+          (message) => message.attachments ?? [],
+        );
+        const attachments = [...transcriptAttachments, ...newAttachments];
+        const summary = buildDraftSummaryWithAttachments(
+          draft.summary,
+          attachments,
+        );
 
         const { data, error: invokeError } =
           await getSupabaseClient().functions.invoke<SubmitResponse>(
@@ -196,6 +254,7 @@ export function useAssistChat(mode: AssistMode = "feedback") {
                 userAgent:
                   typeof navigator !== "undefined" ? navigator.userAgent : "",
                 transcript: messages,
+                attachments,
               },
             },
           );

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "v1.9.83";
+export const APP_VERSION = "v1.9.84";

--- a/supabase/functions/assist-chat/index.ts
+++ b/supabase/functions/assist-chat/index.ts
@@ -19,9 +19,17 @@ type Draft = {
   ready: true;
 };
 
+type AssistAttachment = {
+  url: string;
+  name?: string;
+  type?: string;
+  size?: number;
+};
+
 type RequestBody = {
   sessionId?: string;
   message?: string;
+  attachments?: AssistAttachment[];
   context?: {
     currentRoute?: string;
   };
@@ -36,6 +44,33 @@ function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
     status,
     headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+function normalizeAttachments(value: unknown): AssistAttachment[] {
+  if (!Array.isArray(value)) return [];
+  return value.slice(0, 3).flatMap((item) => {
+    if (!item || typeof item !== "object") return [];
+    const attachment = item as Record<string, unknown>;
+    if (typeof attachment.url !== "string" || !attachment.url) return [];
+    return [
+      {
+        url: attachment.url,
+        name:
+          typeof attachment.name === "string"
+            ? attachment.name.slice(0, 255)
+            : "",
+        type:
+          typeof attachment.type === "string"
+            ? attachment.type.slice(0, 100)
+            : "",
+        size:
+          typeof attachment.size === "number" &&
+          Number.isFinite(attachment.size)
+            ? attachment.size
+            : 0,
+      },
+    ];
   });
 }
 
@@ -63,6 +98,7 @@ async function handler(req: Request, user?: User): Promise<Response> {
   if (!sessionId || !message) {
     return jsonResponse(400, { error: "sessionId and message are required" });
   }
+  const attachments = normalizeAttachments(body.attachments);
 
   // Resolve a human-readable author name from the sales table.
   let authorName = user?.email ?? "Unknown";
@@ -86,7 +122,8 @@ async function handler(req: Request, user?: User): Promise<Response> {
   const payload = {
     mode: "chat",
     sessionId,
-    message: message.slice(0, 4000),
+    message: message.slice(0, 8000),
+    attachments,
     author: {
       name: authorName,
       email: authorEmail,
@@ -94,6 +131,7 @@ async function handler(req: Request, user?: User): Promise<Response> {
     },
     context: {
       currentRoute: body.context?.currentRoute ?? "",
+      attachments,
     },
     source: "nosho-crm",
     submittedAt: new Date().toISOString(),
@@ -127,10 +165,6 @@ async function handler(req: Request, user?: User): Promise<Response> {
     console.error("[assist-chat] failed to parse n8n response:", e);
     return jsonResponse(502, { error: "Invalid response from n8n" });
   }
-
-  console.log(
-    `[assist-chat] ${authorName} (${sessionId}) — reply ${data?.reply?.length ?? 0} chars, draft=${data?.draft ? "yes" : "no"}`,
-  );
 
   return jsonResponse(200, {
     reply: data.reply ?? "",

--- a/supabase/functions/assist-submit/index.ts
+++ b/supabase/functions/assist-submit/index.ts
@@ -15,6 +15,14 @@ type Draft = {
 type ChatMessage = {
   role: "user" | "assistant";
   content: string;
+  attachments?: AssistAttachment[];
+};
+
+type AssistAttachment = {
+  url: string;
+  name?: string;
+  type?: string;
+  size?: number;
 };
 
 type RequestBody = {
@@ -23,6 +31,7 @@ type RequestBody = {
   currentRoute?: string;
   userAgent?: string;
   transcript?: ChatMessage[];
+  attachments?: AssistAttachment[];
 };
 
 function jsonResponse(status: number, body: unknown): Response {
@@ -45,6 +54,33 @@ function isValidDraft(d: unknown): d is Draft {
     draft.summary.length > 0 &&
     draft.ready === true
   );
+}
+
+function normalizeAttachments(value: unknown): AssistAttachment[] {
+  if (!Array.isArray(value)) return [];
+  return value.slice(0, 12).flatMap((item) => {
+    if (!item || typeof item !== "object") return [];
+    const attachment = item as Record<string, unknown>;
+    if (typeof attachment.url !== "string" || !attachment.url) return [];
+    return [
+      {
+        url: attachment.url,
+        name:
+          typeof attachment.name === "string"
+            ? attachment.name.slice(0, 255)
+            : "",
+        type:
+          typeof attachment.type === "string"
+            ? attachment.type.slice(0, 100)
+            : "",
+        size:
+          typeof attachment.size === "number" &&
+          Number.isFinite(attachment.size)
+            ? attachment.size
+            : 0,
+      },
+    ];
+  });
 }
 
 async function handler(req: Request, user?: User): Promise<Response> {
@@ -94,8 +130,10 @@ async function handler(req: Request, user?: User): Promise<Response> {
     ? body.transcript.slice(-20).map((m) => ({
         role: m.role,
         content: typeof m.content === "string" ? m.content.slice(0, 4000) : "",
+        attachments: normalizeAttachments(m.attachments),
       }))
     : [];
+  const attachments = normalizeAttachments(body.attachments);
 
   const payload = {
     mode: "submit",
@@ -111,7 +149,9 @@ async function handler(req: Request, user?: User): Promise<Response> {
     context: {
       currentRoute: body.currentRoute ?? "",
       userAgent: body.userAgent ?? "",
+      attachments,
     },
+    attachments,
     transcript,
   };
 
@@ -146,10 +186,6 @@ async function handler(req: Request, user?: User): Promise<Response> {
   } catch {
     // ignore non-JSON responses
   }
-
-  console.log(
-    `[assist-submit] forwarded ${body.draft.type} from ${authorName}: "${body.draft.title}"`,
-  );
 
   return jsonResponse(200, { ok: true, issueUrl });
 }


### PR DESCRIPTION
## Problem

Nosho AI Assist kept selected images local until final submission, so they were not added to the chat turn and were not forwarded to the brain/n8n context.

## Solution

Upload assist images when the user sends a feedback chat message, render them in the chat bubble, forward normalized attachment metadata through `assist-chat`, and carry those attachments into `assist-submit` and the final draft summary.

## How To Test

Run `make typecheck` and `npx vitest --config vitest.config.ts run src/components/atomic-crm/assist/useAssistChat.test.ts`.

## Additional Checks

- [ ] The **documentation** is up to date
- [ ] Tested with **fakerest** provider (see [related documentation](https://github.com/marmelab/atomic-crm/blob/main/doc/developer/data-providers.md))
- [ ] Tested with **Mobile** resolution
