### PR TITLE
Fix custom view deal creation

### DIFF
--- a/src/components/atomic-crm/deals/DealCreate.tsx
+++ b/src/components/atomic-crm/deals/DealCreate.tsx
@@ -1,4 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
+import { useContext } from "react";
 import {
   Form,
   useDataProvider,
@@ -14,15 +15,21 @@ import { FormToolbar } from "@/components/admin/simple-form";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 
 import type { Deal } from "../types";
+import { useConfigurationContext } from "../root/ConfigurationContext";
 import { DealInputs } from "./DealInputs";
+import { DealListViewContext } from "./DealListContent";
+import { getDefaultDealStage } from "./dealUtils";
 
 export const DealCreate = ({ open }: { open: boolean }) => {
   const redirect = useRedirect();
   const dataProvider = useDataProvider();
   const { data: allDeals } = useListContext<Deal>();
+  const { dealStages } = useConfigurationContext();
+  const { companyType, initialVisibleStages } = useContext(DealListViewContext);
   const location = useLocation();
   const viewMatch = matchPath("/views/:viewId/*", location.pathname);
   const basePath = viewMatch ? `/views/${viewMatch.params.viewId}` : "/deals";
+  const defaultStage = getDefaultDealStage(dealStages, initialVisibleStages);
 
   const handleClose = () => {
     redirect(basePath);
@@ -32,7 +39,8 @@ export const DealCreate = ({ open }: { open: boolean }) => {
 
   const onSuccess = async (deal: Deal) => {
     if (!allDeals) {
-      redirect("/deals");
+      await queryClient.invalidateQueries({ queryKey: ["deals", "getList"] });
+      redirect(basePath);
       return;
     }
     // increase the index of all deals in the same stage as the new deal
@@ -71,6 +79,7 @@ export const DealCreate = ({ open }: { open: boolean }) => {
       },
       { updatedAt: now },
     );
+    await queryClient.invalidateQueries({ queryKey: ["deals", "getList"] });
     redirect(basePath);
   };
 
@@ -85,6 +94,8 @@ export const DealCreate = ({ open }: { open: boolean }) => {
               sales_id: identity?.id,
               contact_ids: [],
               index: 0,
+              company_type: companyType || null,
+              stage: defaultStage,
             }}
           >
             <DealInputs />

--- a/src/components/atomic-crm/deals/DealInputs.tsx
+++ b/src/components/atomic-crm/deals/DealInputs.tsx
@@ -22,6 +22,7 @@ import { contactOptionText } from "../misc/ContactOption";
 import { useConfigurationContext } from "../root/ConfigurationContext";
 import { AutocompleteCompanyInput } from "../companies/AutocompleteCompanyInput.tsx";
 import { DealListViewContext } from "./DealListContent";
+import { getDefaultDealStage } from "./dealUtils";
 import type { Sale } from "../types";
 
 export const DealInputs = () => {
@@ -158,6 +159,9 @@ const DealSalesInput = () => {
 
 const DealMiscInputs = () => {
   const { dealStages, dealCategories } = useConfigurationContext();
+  const { initialVisibleStages } = useContext(DealListViewContext);
+  const defaultStage = getDefaultDealStage(dealStages, initialVisibleStages);
+
   return (
     <div className="flex flex-col gap-4 flex-1">
       <h3 className="text-base font-medium">Divers</h3>
@@ -192,7 +196,7 @@ const DealMiscInputs = () => {
         choices={dealStages}
         optionText="label"
         optionValue="value"
-        defaultValue="opportunity"
+        defaultValue={defaultStage}
         helperText={false}
         validate={required()}
       />

--- a/src/components/atomic-crm/deals/dealUtils.test.ts
+++ b/src/components/atomic-crm/deals/dealUtils.test.ts
@@ -1,6 +1,6 @@
 import { commands } from "vitest/browser";
 
-import { formatISODateString } from "./dealUtils";
+import { formatISODateString, getDefaultDealStage } from "./dealUtils";
 
 describe("formatISODateString", () => {
   let originalTimezone: string;
@@ -50,5 +50,24 @@ describe("formatISODateString", () => {
     expect(() => formatISODateString(invalidDate)).toThrow(
       "Invalid date format. Expected YYYY-MM-DD.",
     );
+  });
+});
+
+describe("getDefaultDealStage", () => {
+  const dealStages = [
+    { value: "lead", label: "Lead" },
+    { value: "qualified", label: "Qualifié" },
+    { value: "closed-won", label: "Gagné" },
+  ];
+
+  it("uses the first visible stage for a custom view", () => {
+    expect(getDefaultDealStage(dealStages, ["qualified", "closed-won"])).toBe(
+      "qualified",
+    );
+  });
+
+  it("falls back to the first configured stage when visible stages are missing or stale", () => {
+    expect(getDefaultDealStage(dealStages, ["opportunity"])).toBe("lead");
+    expect(getDefaultDealStage(dealStages)).toBe("lead");
   });
 });

--- a/src/components/atomic-crm/deals/dealUtils.ts
+++ b/src/components/atomic-crm/deals/dealUtils.ts
@@ -1,5 +1,16 @@
 import { format } from "date-fns";
 
+import type { ConfigurationContextValue } from "../root/ConfigurationContext";
+
+export function getDefaultDealStage(
+  dealStages: ConfigurationContextValue["dealStages"],
+  visibleStages?: string[],
+) {
+  return visibleStages?.find((stage) =>
+    dealStages.some((dealStage) => dealStage.value === stage),
+  ) ?? dealStages[0]?.value;
+}
+
 export function getRelativeTimeString(dateString: string): string {
   const date = new Date(dateString);
   date.setHours(0, 0, 0, 0);

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "v1.9.84";
+export const APP_VERSION = "v1.9.85";


### PR DESCRIPTION
## Problem

Deals created from a custom view such as Investisseur could show the success notification but stay hidden from that view because create defaults did not reliably match the active view and deal lists were not refetched after create-side reindexing.

## Solution

This PR defaults new deals to the active custom view `company_type`, chooses a valid default stage from the view/configuration instead of the stale `opportunity` value, and invalidates deal list queries after creation.

## How To Test

Run `make typecheck` and `npm run test:unit:app -- src/components/atomic-crm/deals/dealUtils.test.ts`; then create a deal from the Investisseur view and confirm it appears after the success notification.

## Additional Checks

- [x] The **documentation** is up to date
- [ ] Tested with **fakerest** provider (see [related documentation](https://github.com/marmelab/atomic-crm/blob/main/doc/developer/data-providers.md))
- [ ] Tested with **Mobile** resolution

